### PR TITLE
Add support for symbolic links

### DIFF
--- a/src/main/filesystem.ts
+++ b/src/main/filesystem.ts
@@ -19,6 +19,7 @@ import {
 import { encrypt } from './utils/safeStorage';
 import { LastFMSessionData } from '../@types/last_fm_api';
 import { DEFAULT_SONG_PALETTE } from './other/generatePalette';
+import isPathADir from './utils/isPathADir';
 
 export const DEFAULT_ARTWORK_SAVE_LOCATION = path.join(app.getPath('userData'), 'song_covers');
 export const DEFAULT_FILE_URL = 'nora://localfiles/';
@@ -569,7 +570,7 @@ function flattenPathArrays<Type extends string[][]>(lists: Type) {
 export const getDirectories = async (srcpath: string) => {
   try {
     const dirs = await fs.readdir(srcpath, { withFileTypes: true });
-    const filteredDirs = dirs.filter((dir) => dir.isDirectory());
+    const filteredDirs = dirs.filter((dir) => isPathADir(dir));
     const dirsWithFullPaths = filteredDirs.map((dir) => path.join(srcpath, dir.name));
 
     return dirsWithFullPaths;

--- a/src/main/utils/copyDir.ts
+++ b/src/main/utils/copyDir.ts
@@ -4,6 +4,7 @@ import fs from 'fs/promises';
 
 import log from '../log';
 import makeDir from './makeDir';
+import isPathADir from './isPathADir';
 
 async function copyDir(src: string, dest: string) {
   try {
@@ -16,7 +17,7 @@ async function copyDir(src: string, dest: string) {
       const srcPath = path.join(src, entry.name);
       const destPath = path.join(dest, entry.name);
 
-      if (entry.isDirectory()) await copyDir(srcPath, destPath);
+      if (isPathADir(entry)) await copyDir(srcPath, destPath);
       else await fs.copyFile(srcPath, destPath);
     }
   } catch (error) {

--- a/src/main/utils/getDirSize.ts
+++ b/src/main/utils/getDirSize.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { isAnErrorWithCode } from './isAnErrorWithCode';
+import isPathADir from './isPathADir';
 
 const getDirSize = async (dir: string) => {
   try {
@@ -10,7 +11,7 @@ const getDirSize = async (dir: string) => {
       try {
         const filepath = path.join(dir, file.name);
 
-        if (file.isDirectory()) return getDirSize(filepath);
+        if (isPathADir(file)) return getDirSize(filepath);
         if (file.isFile()) {
           const { size } = await fs.stat(filepath);
           return size;

--- a/src/main/utils/isPathADir.ts
+++ b/src/main/utils/isPathADir.ts
@@ -1,26 +1,26 @@
 import path from 'path';
 import fs, { Dirent } from 'fs';
 
-const isPathADir = (pathForDir: string | Dirent) => {
-  if (typeof pathForDir === 'string') {
-    const stat = fs.statSync(pathForDir);
+const isPathADir = (pathOrDir: string | Dirent) => {
+  if (typeof pathOrDir === 'string') {
+    const stat = fs.statSync(pathOrDir);
 
     if (stat.isDirectory()) return true;
 
     if (!stat.isSymbolicLink()) return false;
 
-    const symlinkTarget = fs.readlinkSync(pathForDir);
+    const symlinkTarget = fs.readlinkSync(pathOrDir);
 
     const symlinkStat = fs.statSync(symlinkTarget);
 
     return symlinkStat.isDirectory();
   }
 
-  if (pathForDir.isDirectory()) return true;
+  if (pathOrDir.isDirectory()) return true;
 
-  if (!pathForDir.isSymbolicLink()) return false;
+  if (!pathOrDir.isSymbolicLink()) return false;
 
-  const symlinkPath = path.join(pathForDir.path, pathForDir.name);
+  const symlinkPath = path.join(pathOrDir.path, pathOrDir.name);
 
   const symlinkStat = fs.statSync(symlinkPath);
 

--- a/src/main/utils/isPathADir.ts
+++ b/src/main/utils/isPathADir.ts
@@ -2,29 +2,34 @@ import path from 'path';
 import fs, { Dirent } from 'fs';
 
 const isPathADir = (pathOrDir: string | Dirent) => {
-  if (typeof pathOrDir === 'string') {
-    const stat = fs.statSync(pathOrDir);
+  try {
+    if (typeof pathOrDir === 'string') {
+      const stat = fs.statSync(pathOrDir);
 
-    if (stat.isDirectory()) return true;
+      if (stat.isDirectory()) return true;
 
-    if (!stat.isSymbolicLink()) return false;
+      if (!stat.isSymbolicLink()) return false;
 
-    const symlinkTarget = fs.readlinkSync(pathOrDir);
+      const symlinkTarget = fs.readlinkSync(pathOrDir);
 
-    const symlinkStat = fs.statSync(symlinkTarget);
+      const symlinkStat = fs.statSync(symlinkTarget);
+
+      return symlinkStat.isDirectory();
+    }
+
+    if (pathOrDir.isDirectory()) return true;
+
+    if (!pathOrDir.isSymbolicLink()) return false;
+
+    const symlinkPath = path.join(pathOrDir.path, pathOrDir.name);
+
+    const symlinkStat = fs.statSync(symlinkPath);
 
     return symlinkStat.isDirectory();
+  } catch {
+    return false;
   }
-
-  if (pathOrDir.isDirectory()) return true;
-
-  if (!pathOrDir.isSymbolicLink()) return false;
-
-  const symlinkPath = path.join(pathOrDir.path, pathOrDir.name);
-
-  const symlinkStat = fs.statSync(symlinkPath);
-
-  return symlinkStat.isDirectory();
 };
 
 export default isPathADir;
+

--- a/src/main/utils/isPathADir.ts
+++ b/src/main/utils/isPathADir.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+import fs, { Dirent } from 'fs';
+
+const isPathADir = (pathForDir: string | Dirent) => {
+  if (typeof pathForDir === 'string') {
+    const stat = fs.statSync(pathForDir);
+
+    if (stat.isDirectory()) return true;
+
+    if (!stat.isSymbolicLink()) return false;
+
+    const symlinkTarget = fs.readlinkSync(pathForDir);
+
+    const symlinkStat = fs.statSync(symlinkTarget);
+
+    return symlinkStat.isDirectory();
+  }
+
+  if (pathForDir.isDirectory()) return true;
+
+  if (!pathForDir.isSymbolicLink()) return false;
+
+  const symlinkPath = path.join(pathForDir.path, pathForDir.name);
+
+  const symlinkStat = fs.statSync(symlinkPath);
+
+  return symlinkStat.isDirectory();
+};
+
+export default isPathADir;


### PR DESCRIPTION
This PR aims to add support for Symbolic Links while fetching directories for songs. It adds an util function called `isPathADir` that checks a given path or Dirent (`fs.readdir` return type) if it's a directory, then if it's a symbolic link, then if the symbolic link target is a directory, using synchronous `fs` functions. I've replaced all occurrences of `.isDirectory()` to this util function. Please tell me if I've missed something. Thanks!