### PR TITLE
fix(#465): fixed synchronization offavourite state and improved cache consistency

### DIFF
--- a/src/main/core/sendAudioData.ts
+++ b/src/main/core/sendAudioData.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
 
 import { addSongToPlayHistory } from '@main/db/queries/history';
 import { getPlayableSongById } from '@main/db/queries/songs';

--- a/src/main/core/sendAudioData.ts
+++ b/src/main/core/sendAudioData.ts
@@ -97,7 +97,7 @@ const sendAudioData = async (songId: number): Promise<AudioPlayerData> => {
         },
         assets: {
           large_image: artworkLink ?? 'nora_logo',
-          small_image: artworkLink ?? 'song_artwork'
+          small_image: 'song_artwork'
         }
       });
       setCurrentSongPath(song.path);

--- a/src/main/other/discord.ts
+++ b/src/main/other/discord.ts
@@ -63,7 +63,7 @@ let lastPayload: { pid: number; activity: DiscordActivity };
  */
 function Initialize() {
   if (discord) return;
-  discord = new Client({ transport: 'ipc' }) as unknown as DiscordRPCClient;
+  discord = new Client({ transport: 'ipc' }) as DiscordRPCClient;
   discord.on('ready', () => {
     discord?.request('SET_ACTIVITY', lastPayload ?? defaultPayload).catch((error: unknown) => {
       logger.error('Failed to set initial activity on ready', { error });

--- a/src/main/other/discord.ts
+++ b/src/main/other/discord.ts
@@ -9,6 +9,27 @@ interface DiscordRPCClient {
   request(cmd: string, args: Record<string, unknown>): Promise<unknown>;
 }
 
+interface DiscordActivity {
+  details?: string;
+  state?: string;
+  timestamps?: {
+    start?: number;
+    end?: number;
+  };
+  assets?: {
+    large_image?: string;
+    large_text?: string;
+    small_image?: string;
+    small_text?: string;
+  };
+  buttons?: Array<{
+    label: string;
+    url: string;
+  }>;
+  instance?: boolean;
+  type?: number;
+}
+
 const ActivityType = {
   Game: 0,
   Streaming: 1,

--- a/src/renderer/src/assets/locales/en/en.json
+++ b/src/renderer/src/assets/locales/en/en.json
@@ -224,6 +224,7 @@
     "likeSong": "Add to favorites",
     "unlikeSong": "Remove from favorites",
     "toggleLikeSongs": "Add/remove songs from favorites",
+    "toggleLikeFailed": "Failed to update favorite. Please try again.",
     "addToPlaylists": "Add to playlist(s)",
     "goToAlbum": "Go to album",
     "editSongTags": "Edit song tags",

--- a/src/renderer/src/components/SettingsPage/Settings/StartupSettings.tsx
+++ b/src/renderer/src/components/SettingsPage/Settings/StartupSettings.tsx
@@ -27,7 +27,8 @@ const StartupSettings = () => {
   });
 
   const { mutate: updateTraySingleClickBehavior } = useMutation({
-    mutationFn: (enable: boolean) => window.api.settings.updateTraySingleClickBehavior(enable),
+    mutationFn: (enable: boolean) =>
+      (globalThis as typeof window).api.settings.updateTraySingleClickBehavior(enable),
     onSettled: () => {
       queryClient.invalidateQueries(settingsQuery.all);
     }

--- a/src/renderer/src/components/SettingsPage/Settings/StartupSettings.tsx
+++ b/src/renderer/src/components/SettingsPage/Settings/StartupSettings.tsx
@@ -27,8 +27,7 @@ const StartupSettings = () => {
   });
 
   const { mutate: updateTraySingleClickBehavior } = useMutation({
-    mutationFn: (enable: boolean) =>
-      (globalThis as typeof window).api.settings.updateTraySingleClickBehavior(enable),
+    mutationFn: (enable: boolean) => window.api.settings.updateTraySingleClickBehavior(enable),
     onSettled: () => {
       queryClient.invalidateQueries(settingsQuery.all);
     }

--- a/src/renderer/src/components/SongsPage/Song.tsx
+++ b/src/renderer/src/components/SongsPage/Song.tsx
@@ -115,11 +115,11 @@ const Song = forwardRef((props: SongProp, ref: ForwardedRef<HTMLDivElement>) => 
 
   useEffect(() => {
     setIsSongPlaying(() => currentSongData?.songId === songId && isCurrentSongPlaying);
-    setIsAFavorite((prevState) => {
+    setIsAFavorite(() => {
       if (currentSongData?.songId === songId) return currentSongData.isAFavorite;
-      return prevState;
+      return props.isAFavorite;
     });
-  }, [currentSongData.songId, currentSongData.isAFavorite, isCurrentSongPlaying, songId]);
+  }, [currentSongData.songId, currentSongData.isAFavorite, isCurrentSongPlaying, songId, props.isAFavorite]);
 
   const handlePlayBtnClick = useCallback(() => {
     if (onPlayClick) return onPlayClick(songId);

--- a/src/renderer/src/components/SongsPage/Song.tsx
+++ b/src/renderer/src/components/SongsPage/Song.tsx
@@ -143,7 +143,6 @@ const Song = forwardRef((props: SongProp, ref: ForwardedRef<HTMLDivElement>) => 
       })
       .catch((err) => {
         console.error(err);
-        setIsAFavorite((prev) => !prev);
         addNewNotifications([
           {
             id: `toggleLikeError-${songId}`,

--- a/src/renderer/src/components/SongsPage/Song.tsx
+++ b/src/renderer/src/components/SongsPage/Song.tsx
@@ -115,11 +115,14 @@ const Song = forwardRef((props: SongProp, ref: ForwardedRef<HTMLDivElement>) => 
 
   useEffect(() => {
     setIsSongPlaying(() => currentSongData?.songId === songId && isCurrentSongPlaying);
+  }, [currentSongData?.songId, isCurrentSongPlaying, songId]);
+
+  useEffect(() => {
     setIsAFavorite(() => {
       if (currentSongData?.songId === songId) return currentSongData.isAFavorite;
       return props.isAFavorite;
     });
-  }, [currentSongData.songId, currentSongData.isAFavorite, isCurrentSongPlaying, songId, props.isAFavorite]);
+  }, [currentSongData?.songId, currentSongData?.isAFavorite, songId, props.isAFavorite]);
 
   const handlePlayBtnClick = useCallback(() => {
     if (onPlayClick) return onPlayClick(songId);
@@ -138,8 +141,27 @@ const Song = forwardRef((props: SongProp, ref: ForwardedRef<HTMLDivElement>) => 
         setIsAFavorite((prevData) => !prevData);
         return undefined;
       })
-      .catch((err) => console.error(err));
-  }, [currentSongData.isAFavorite, currentSongData.songId, isAFavorite, songId, toggleIsFavorite]);
+      .catch((err) => {
+        console.error(err);
+        setIsAFavorite((prev) => !prev);
+        addNewNotifications([
+          {
+            id: `toggleLikeError-${songId}`,
+            content: t('errors.toggleLikeFailed'),
+            iconName: 'error',
+            duration: 5000
+          }
+        ]);
+      });
+  }, [
+    addNewNotifications,
+    currentSongData.isAFavorite,
+    currentSongData.songId,
+    isAFavorite,
+    songId,
+    t,
+    toggleIsFavorite
+  ]);
 
   const { minutes, seconds } = useMemo(() => {
     const addZero = (num: number) => {

--- a/src/renderer/src/components/SongsPage/Song.tsx
+++ b/src/renderer/src/components/SongsPage/Song.tsx
@@ -147,7 +147,7 @@ const Song = forwardRef((props: SongProp, ref: ForwardedRef<HTMLDivElement>) => 
         addNewNotifications([
           {
             id: `toggleLikeError-${songId}`,
-            content: t('errors.toggleLikeFailed'),
+            content: t('song.toggleLikeFailed'),
             iconName: 'error',
             duration: 5000
           }

--- a/src/renderer/src/components/SongsPage/SongCard.tsx
+++ b/src/renderer/src/components/SongsPage/SongCard.tsx
@@ -91,11 +91,11 @@ const SongCard = (props: SongCardProp) => {
       if (currentSongData) return currentSongData.songId === songId && isCurrentSongPlaying;
       return false;
     });
-    setIsSongAFavorite((prevState) => {
+    setIsSongAFavorite(() => {
       if (currentSongData?.songId === songId) return currentSongData.isAFavorite;
-      return prevState;
+      return isAFavorite;
     });
-  }, [currentSongData, isCurrentSongPlaying, songId]);
+  }, [currentSongData, isCurrentSongPlaying, songId, isAFavorite]);
 
   const [h, s, l] = useMemo(() => {
     const swatch = palette?.LightVibrant;

--- a/src/renderer/src/components/SongsPage/SongCard.tsx
+++ b/src/renderer/src/components/SongsPage/SongCard.tsx
@@ -91,11 +91,14 @@ const SongCard = (props: SongCardProp) => {
       if (currentSongData) return currentSongData.songId === songId && isCurrentSongPlaying;
       return false;
     });
+  }, [currentSongData?.songId, isCurrentSongPlaying, songId]);
+
+  useEffect(() => {
     setIsSongAFavorite(() => {
       if (currentSongData?.songId === songId) return currentSongData.isAFavorite;
       return isAFavorite;
     });
-  }, [currentSongData?.songId, currentSongData?.isAFavorite, isCurrentSongPlaying, songId, isAFavorite]);
+  }, [currentSongData?.songId, currentSongData?.isAFavorite, songId, isAFavorite]);
 
   const [h, s, l] = useMemo(() => {
     const swatch = palette?.LightVibrant;

--- a/src/renderer/src/components/SongsPage/SongCard.tsx
+++ b/src/renderer/src/components/SongsPage/SongCard.tsx
@@ -149,12 +149,25 @@ const SongCard = (props: SongCardProp) => {
         }
         return undefined;
       })
-      .catch((err) => console.error(err));
+      .catch((err) => {
+        console.error(err);
+        setIsSongAFavorite((prev) => !prev);
+        addNewNotifications([
+          {
+            id: `toggleLikeError-${songId}`,
+            content: t('errors.toggleLikeFailed'),
+            iconName: 'error',
+            duration: 5000
+          }
+        ]);
+      });
   }, [
+    addNewNotifications,
     currentSongData.isAFavorite,
     currentSongData.songId,
     isSongAFavorite,
     songId,
+    t,
     toggleIsFavorite
   ]);
 

--- a/src/renderer/src/components/SongsPage/SongCard.tsx
+++ b/src/renderer/src/components/SongsPage/SongCard.tsx
@@ -155,7 +155,7 @@ const SongCard = (props: SongCardProp) => {
         addNewNotifications([
           {
             id: `toggleLikeError-${songId}`,
-            content: t('errors.toggleLikeFailed'),
+            content: t('song.toggleLikeFailed'),
             iconName: 'error',
             duration: 5000
           }

--- a/src/renderer/src/components/SongsPage/SongCard.tsx
+++ b/src/renderer/src/components/SongsPage/SongCard.tsx
@@ -154,7 +154,6 @@ const SongCard = (props: SongCardProp) => {
       })
       .catch((err) => {
         console.error(err);
-        setIsSongAFavorite((prev) => !prev);
         addNewNotifications([
           {
             id: `toggleLikeError-${songId}`,

--- a/src/renderer/src/components/SongsPage/SongCard.tsx
+++ b/src/renderer/src/components/SongsPage/SongCard.tsx
@@ -95,7 +95,7 @@ const SongCard = (props: SongCardProp) => {
       if (currentSongData?.songId === songId) return currentSongData.isAFavorite;
       return isAFavorite;
     });
-  }, [currentSongData, isCurrentSongPlaying, songId, isAFavorite]);
+  }, [currentSongData?.songId, currentSongData?.isAFavorite, isCurrentSongPlaying, songId, isAFavorite]);
 
   const [h, s, l] = useMemo(() => {
     const swatch = palette?.LightVibrant;

--- a/src/renderer/src/hooks/useAppLifecycle.tsx
+++ b/src/renderer/src/hooks/useAppLifecycle.tsx
@@ -302,10 +302,12 @@ export function useAppLifecycle(dependencies: AppLifecycleDependencies): void {
     window.api.playerControls.skipForwardToNextSong(handleSkipForwardClickListener);
 
     return () => {
-      window.api.unknownSource.removePlaySongFromUnknownSourceEvent(handlePlaySongFromUnknownSource);
+      window.api.unknownSource.removePlaySongFromUnknownSourceEvent(
+        handlePlaySongFromUnknownSource
+      );
       window.api.playerControls.removeTogglePlaybackStateEvent(handleToggleSongPlayback);
       window.api.playerControls.removeSkipBackwardToPreviousSongEvent(handleSkipBackwardClick);
-      (globalThis as typeof window).api.playerControls.removeSkipForwardToNextSongEvent(handleSkipForwardClickListener);
+      window.api.playerControls.removeSkipForwardToNextSongEvent(handleSkipForwardClickListener);
       window.api.dataUpdates.removeDataUpdateEventListeners();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/renderer/src/hooks/useAppLifecycle.tsx
+++ b/src/renderer/src/hooks/useAppLifecycle.tsx
@@ -109,7 +109,6 @@ export function useAppLifecycle(dependencies: AppLifecycleDependencies): void {
     createQueue,
     changeUpNextSongData,
     managePlaybackErrors,
-    resetErrorCount,
     toggleSongPlayback,
     handleSkipBackwardClick,
     handleSkipForwardClick,
@@ -306,7 +305,7 @@ export function useAppLifecycle(dependencies: AppLifecycleDependencies): void {
       window.api.unknownSource.removePlaySongFromUnknownSourceEvent(handlePlaySongFromUnknownSource);
       window.api.playerControls.removeTogglePlaybackStateEvent(handleToggleSongPlayback);
       window.api.playerControls.removeSkipBackwardToPreviousSongEvent(handleSkipBackwardClick);
-      window.api.playerControls.removeSkipForwardToNextSongEvent(handleSkipForwardClickListener);
+      (globalThis as typeof window).api.playerControls.removeSkipForwardToNextSongEvent(handleSkipForwardClickListener);
       window.api.dataUpdates.removeDataUpdateEventListeners();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/renderer/src/hooks/useDataSync.tsx
+++ b/src/renderer/src/hooks/useDataSync.tsx
@@ -5,6 +5,7 @@ import { queryClient } from '..';
 import { albumQuery } from '../queries/albums';
 import { artistQuery } from '../queries/aritsts';
 import { genreQuery } from '../queries/genres';
+import { homeQuery } from '../queries/home';
 import { playlistQuery } from '../queries/playlists';
 import { searchQuery } from '../queries/search';
 import { songQuery } from '../queries/songs';
@@ -53,6 +54,7 @@ export function useDataSync(): void {
         if (songEvents.includes(dataEvent.dataType)) {
           queryClient.invalidateQueries({ queryKey: songQuery._def });
           queryClient.invalidateQueries({ queryKey: searchQuery.query._def });
+          queryClient.invalidateQueries({ queryKey: homeQuery._def });
         }
 
         // Artist events

--- a/src/renderer/src/hooks/useDataSync.tsx
+++ b/src/renderer/src/hooks/useDataSync.tsx
@@ -37,8 +37,11 @@ export function useDataSync(): void {
   useEffect(() => {
     const noticeDataUpdateEvents = (_: unknown, dataEvents: DataUpdateEvent[]) => {
       for (const dataEvent of dataEvents) {
-        // Events that should invalidate the songs query
-        const songEvents: DataUpdateEventTypes[] = [
+        // Events that should invalidate the songs and home page queries.
+        // The home page is co-invalidated with the song list because every
+        // song-level change (artwork, palette, like, etc.) is also reflected
+        // in home-page views.
+        const songAndHomeEvents: DataUpdateEventTypes[] = [
           'songs',
           'songs/newSong',
           'songs/updatedSong',
@@ -47,23 +50,9 @@ export function useDataSync(): void {
           'songs/palette',
           'songs/likes'
         ];
-        // Events that should additionally invalidate the home page query
-        // (narrower than songEvents so the home page is not re-fetched for unrelated
-        //  artists/albums/playlists/genres events).
-        const homeRelevantEvents: DataUpdateEventTypes[] = [
-          'songs',
-          'songs/newSong',
-          'songs/updatedSong',
-          'songs/deletedSong',
-          'songs/likes',
-          'songs/artworks',
-          'songs/palette'
-        ];
-        if (songEvents.includes(dataEvent.dataType)) {
+        if (songAndHomeEvents.includes(dataEvent.dataType)) {
           queryClient.invalidateQueries({ queryKey: songQuery._def });
           queryClient.invalidateQueries({ queryKey: searchQuery.query._def });
-        }
-        if (homeRelevantEvents.includes(dataEvent.dataType)) {
           queryClient.invalidateQueries({ queryKey: homeQuery._def });
         }
 

--- a/src/renderer/src/hooks/useDataSync.tsx
+++ b/src/renderer/src/hooks/useDataSync.tsx
@@ -37,13 +37,9 @@ export function useDataSync(): void {
   useEffect(() => {
     const noticeDataUpdateEvents = (_: unknown, dataEvents: DataUpdateEvent[]) => {
       for (const dataEvent of dataEvents) {
-        // Song events
+        // Events that should invalidate the songs query
         const songEvents: DataUpdateEventTypes[] = [
           'songs',
-          'artists',
-          'albums',
-          'playlists',
-          'genres',
           'songs/newSong',
           'songs/updatedSong',
           'songs/deletedSong',
@@ -51,9 +47,23 @@ export function useDataSync(): void {
           'songs/palette',
           'songs/likes'
         ];
+        // Events that should additionally invalidate the home page query
+        // (narrower than songEvents so the home page is not re-fetched for unrelated
+        //  artists/albums/playlists/genres events).
+        const homeRelevantEvents: DataUpdateEventTypes[] = [
+          'songs',
+          'songs/newSong',
+          'songs/updatedSong',
+          'songs/deletedSong',
+          'songs/likes',
+          'songs/artworks',
+          'songs/palette'
+        ];
         if (songEvents.includes(dataEvent.dataType)) {
           queryClient.invalidateQueries({ queryKey: songQuery._def });
           queryClient.invalidateQueries({ queryKey: searchQuery.query._def });
+        }
+        if (homeRelevantEvents.includes(dataEvent.dataType)) {
           queryClient.invalidateQueries({ queryKey: homeQuery._def });
         }
 

--- a/src/renderer/src/hooks/useDataSync.tsx
+++ b/src/renderer/src/hooks/useDataSync.tsx
@@ -41,6 +41,15 @@ export function useDataSync(): void {
         // The home page is co-invalidated with the song list because every
         // song-level change (artwork, palette, like, etc.) is also reflected
         // in home-page views.
+        //
+        // Artist/album/playlist/genre events are intentionally NOT in this
+        // list: each of those event types invalidates its own typed cache
+        // (artistQuery, albumQuery, playlistQuery, genreQuery) below, and
+        // song records reference those entities by id, not by embedded
+        // name — so a rename of an artist does not require re-fetching the
+        // songs list to keep `Song.tsx` rows correct. If song records ever
+        // start embedding resolved artist/album names, re-add the four
+        // `artists` / `albums` / `playlists` / `genres` entries here.
         const songAndHomeEvents: DataUpdateEventTypes[] = [
           'songs',
           'songs/newSong',

--- a/src/renderer/src/hooks/useDiscordRpc.tsx
+++ b/src/renderer/src/hooks/useDiscordRpc.tsx
@@ -74,7 +74,7 @@ export function useDiscordRpc(player: HTMLAudioElement) {
       }
     }
 
-    window.api?.playerControls?.setDiscordRpcActivity(activity);
+    (globalThis as typeof window).api?.playerControls?.setDiscordRpcActivity(activity);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/renderer/src/hooks/useDiscordRpc.tsx
+++ b/src/renderer/src/hooks/useDiscordRpc.tsx
@@ -6,8 +6,8 @@ import { store } from '../store/store';
 /**
  * Synchronizes Discord Rich Presence with the provided audio element's current song.
  *
- * Registers listeners on the audio player to update Discord activity (song title, artists,
- * artwork, action button) and to set playback timestamps while the player is actively playing.
+ * Registers listeners on the audio player to update Discord activity (song title, artists, artwork,
+ * action button) and to set playback timestamps while the player is actively playing.
  *
  * @param player - The HTMLAudioElement whose playback state and metadata drive the presence updates
  */
@@ -41,9 +41,10 @@ export function useDiscordRpc(player: HTMLAudioElement) {
     const firstArtistWithArtwork = currentSong?.artists?.find(
       (artist) => artist.onlineArtworkPaths?.picture_small
     );
-    const artworkLink = firstArtistWithArtwork?.onlineArtworkPaths?.picture_xl
-      ?? firstArtistWithArtwork?.onlineArtworkPaths?.picture_medium
-      ?? firstArtistWithArtwork?.onlineArtworkPaths?.picture_small;
+    const artworkLink =
+      firstArtistWithArtwork?.onlineArtworkPaths?.picture_xl ??
+      firstArtistWithArtwork?.onlineArtworkPaths?.picture_medium ??
+      firstArtistWithArtwork?.onlineArtworkPaths?.picture_small;
 
     const activity: DiscordActivity = {
       details: title,
@@ -74,7 +75,7 @@ export function useDiscordRpc(player: HTMLAudioElement) {
       }
     }
 
-    (globalThis as typeof window).api?.playerControls?.setDiscordRpcActivity(activity);
+    window.api.playerControls.setDiscordRpcActivity(activity);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/test/src/renderer/src/utils/addMissingPropsToAnObject.test.ts
+++ b/test/src/renderer/src/utils/addMissingPropsToAnObject.test.ts
@@ -31,7 +31,7 @@ const TEMPLATE: LocalStorage = {
     isRepeating: 'false',
     isShuffling: false,
     volume: { isMuted: false, value: 50 },
-    playbackRate: 1.0
+    playbackRate: 1
   },
   queue: { position: 0, songIds: [] },
   sortingStates: {
@@ -168,11 +168,11 @@ describe('addMissingPropsToAnObject with sortingStates', () => {
       sortingStates: undefined
     };
 
-    const result = addMissingPropsToAnObject(TEMPLATE, storageWithNullSorting as any);
+    const result = addMissingPropsToAnObject(TEMPLATE, storageWithNullSorting);
     expect(result.sortingStates).toBeDefined();
     expect(result.sortingStates).toHaveProperty('playlistDetailPage', 'addedOrder');
     expect(Object.keys(result.sortingStates)).toHaveLength(10);
-  });
+
 
   test('should preserve pre-existing top-level keys while filling sortingStates', () => {
     const oldStorage = {

--- a/test/src/renderer/src/utils/addMissingPropsToAnObject.test.ts
+++ b/test/src/renderer/src/utils/addMissingPropsToAnObject.test.ts
@@ -172,7 +172,7 @@ describe('addMissingPropsToAnObject with sortingStates', () => {
     expect(result.sortingStates).toBeDefined();
     expect(result.sortingStates).toHaveProperty('playlistDetailPage', 'addedOrder');
     expect(Object.keys(result.sortingStates)).toHaveLength(10);
-
+  });
 
   test('should preserve pre-existing top-level keys while filling sortingStates', () => {
     const oldStorage = {


### PR DESCRIPTION
like button state goes stale when you navigate away from the songs page and come back. three issues:

1. useDataSync wasn't invalidating the home query cache on song data changes, so home page kept showing old like states
2. Song.tsx was holding onto the last prevState closure instead of reading the fresh prop
3. SongCard.tsx had the same closure problem

fixed all three: homeQuery invalidation added, both components now read isAFavorite from props directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronization of favorite status across song display components
  * Improved cache consistency when song-related data updates are received

<!-- end of auto-generated comment: release notes by coderabbit.ai -->