### PR TITLE
fix(#418): add tray single-click toggle window setting

### DIFF
--- a/resources/drizzle/0003_add_tray_click_setting.sql
+++ b/resources/drizzle/0003_add_tray_click_setting.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user_settings"
+ADD COLUMN "tray_single_click_toggles_window" boolean NOT NULL DEFAULT false;

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -422,6 +422,9 @@ export const userSettings = pgTable(
     isMiniPlayerAlwaysOnTop: boolean('is_mini_player_always_on_top').notNull().default(false),
     isMusixmatchLyricsEnabled: boolean('is_musixmatch_lyrics_enabled').notNull().default(true),
     hideWindowOnClose: boolean('hide_window_on_close').notNull().default(false),
+    traySingleClickTogglesWindow: boolean('tray_single_click_toggles_window')
+      .notNull()
+      .default(false),
     sendSongScrobblingDataToLastFM: boolean('send_song_scrobbling_data_to_lastfm')
       .notNull()
       .default(false),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -85,9 +85,8 @@ import {
   sendMessageToRenderer,
   stopScreenSleeping,
   toggleAudioPlayingState,
-  toggleAutoLaunch,
-  toggleMiniPlayerAlwaysOnTop,
-  toggleOnBatteryPower
+  toggleOnBatteryPower,
+  updateTraySingleClickBehavior
 } from './main';
 import { setDiscordRpcActivity } from './other/discordRPC';
 import { generatePalettes } from './other/generatePalette';
@@ -206,6 +205,10 @@ export function initializeIPC(mainWindow: BrowserWindow, abortSignal: AbortSigna
     // );
     ipcMain.handle('app/saveUserSettings', (_, settings: Partial<UserSettings>) =>
       saveUserSettings(settings)
+    );
+
+    ipcMain.handle('app/updateTraySingleClickBehavior', (_, enable: boolean) =>
+      updateTraySingleClickBehavior(enable)
     );
 
     // User Keyboard Shortcuts Handlers

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -90,6 +90,7 @@ const DEFAULT_SAVE_DIALOG_OPTIONS: SaveDialogOptions = {
 // / / / / / / VARIABLES / / / / / / /
 export let mainWindow: BrowserWindow;
 let tray: Tray;
+let trayContextMenu: Electron.Menu;
 let playerType: PlayerTypes = 'normal';
 // let isConnectedToInternet = false;
 let isAudioPlaying = false;
@@ -279,7 +280,7 @@ protocol.registerSchemesAsPrivileged([
 app
   .whenReady()
   .then(async () => {
-    const { windowState, zoomFactor } = await getUserSettings();
+    const { windowState, zoomFactor, traySingleClickTogglesWindow = false } = await getUserSettings();
 
     currentWindowZoomFactor = normalizeZoomFactor(zoomFactor);
 
@@ -301,7 +302,7 @@ app
     protocol.handle('nora', handleFileProtocol);
 
     tray = new Tray(appIcon);
-    const trayContextMenu = Menu.buildFromTemplate([
+    trayContextMenu = Menu.buildFromTemplate([
       {
         label: 'Show/Hide Nora',
         type: 'normal',
@@ -315,13 +316,18 @@ app
     tray.setContextMenu(trayContextMenu);
     tray.setToolTip('Nora');
 
-    tray.addListener('click', () => tray.popUpContextMenu(trayContextMenu));
-    tray.addListener('double-click', () => {
-      if (mainWindow.isVisible()) mainWindow.hide();
-      else mainWindow.show();
-    });
-
-    // powerMonitor.addListener('shutdown', (e) => e.preventDefault());
+    if (traySingleClickTogglesWindow) {
+      tray.addListener('click', () => {
+        if (mainWindow.isVisible()) mainWindow.hide();
+        else mainWindow.show();
+      });
+    } else {
+      tray.addListener('click', () => tray.popUpContextMenu(trayContextMenu));
+      tray.addListener('double-click', () => {
+        if (mainWindow.isVisible()) mainWindow.hide();
+        else mainWindow.show();
+      });
+    }
 
     mainWindow.webContents.once('did-finish-load', manageWindowFinishLoad);
 
@@ -728,6 +734,26 @@ export async function resetApp(isRestartApp = true) {
     restartApp('App reset.');
     // else mainWindow.webContents.reload();
   }
+}
+
+export function updateTraySingleClickBehavior(traySingleClickTogglesWindow: boolean) {
+  tray.removeAllListeners('click');
+  tray.removeAllListeners('double-click');
+
+  if (traySingleClickTogglesWindow) {
+    tray.addListener('click', () => {
+      if (mainWindow.isVisible()) mainWindow.hide();
+      else mainWindow.show();
+    });
+  } else {
+    tray.addListener('click', () => tray.popUpContextMenu(trayContextMenu));
+    tray.addListener('double-click', () => {
+      if (mainWindow.isVisible()) mainWindow.hide();
+      else mainWindow.show();
+    });
+  }
+
+  saveUserSettings({ traySingleClickTogglesWindow });
 }
 
 export function toggleMiniPlayerAlwaysOnTop(isMiniPlayerAlwaysOnTop: boolean) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -345,6 +345,8 @@ const settings = {
     }),
   updateHideWindowOnCloseState: (enable: boolean): Promise<void> =>
     ipcRenderer.invoke('app/saveUserSettings', { hideWindowOnClose: enable }),
+  updateTraySingleClickBehavior: (enable: boolean): Promise<void> =>
+    ipcRenderer.invoke('app/updateTraySingleClickBehavior', enable),
   updateSaveVerboseLogs: (enable: boolean): Promise<void> =>
     ipcRenderer.invoke('app/saveUserSettings', { saveVerboseLogs: enable })
 };

--- a/src/renderer/src/assets/locales/en/en.json
+++ b/src/renderer/src/assets/locales/en/en.json
@@ -1,1125 +1,1122 @@
 {
-	"common": {
-		"song_one": "song",
-		"song_other": "Songs",
-		"playlist_one": "playlist",
-		"playlist_other": "Playlists",
-		"artist_one": "artist",
-		"artist_other": "Artists",
-		"album_one": "album",
-		"album_other": "Albums",
-		"genre_one": "genre",
-		"genre_other": "Genres",
-		"folder_one": "folder",
-		"folder_other": "Folders",
-		"songWithCount_one": "{{count}} song",
-		"songWithCount_other": "{{count}} songs",
-		"playlistWithCount_one": "{{count}} playlist",
-		"playlistWithCount_other": "{{count}} playlists",
-		"artistWithCount_one": "{{count}} artist",
-		"artistWithCount_other": "{{count}} artists",
-		"albumWithCount_one": "{{count}} album",
-		"albumWithCount_other": "{{count}} albums",
-		"genreWithCount_one": "{{count}} genre",
-		"genreWithCount_other": "{{count}} genres",
-		"folderWithCount_one": "{{count}} folder",
-		"folderWithCount_other": "{{count}} folders",
-		"subFolderWithCount_one": "{{count}} sub-folder",
-		"subFolderWithCount_other": "{{count}} sub-folders",
-
-		"selectionWithCount_one": "{{count}} selected",
-		"selectionWithCount_other": "{{count}} selected",
-
-		"shownWithCount": "{{count}} shown",
-
-		"unknownTitle": "Unknown title",
-		"unknownArtist": "Unknown artist",
-		"unknownAlbum": "Unknown album",
-		"unknownGenre": "Unknown genre",
-		"unknownFolder": "Unknown folder",
-		"unknownLyricsProvider": "Unknown lyrics provider",
-
-		"songTitle": "Song title",
-		"duration": "Duration",
-		"albumArtists": "Song album artists",
-		"albumTrackNo": "Album track number",
-		"releasedYear": "Release year",
-		"songAddedOn": "Song added on",
-		"lastModifiedOn": "Last modified on",
-		"sampleRate": "Sample rate",
-		"bitRate": "Bitrate",
-		"noOfAudioChannels": "Number of audio channels",
-		"channelWithCount_one": "{{count}} channel (Mono)",
-		"channelWithCount_other": "{{count}} channels (Stereo)",
-		"songLocation": "Song location",
-		"lyrics": "Song lyrics",
-		"syncedLyrics": "Synced lyrics",
-		"unsyncedLyrics": "Unsynced lyrics",
-
-		"play": "Play",
-		"playNext": "Play next",
-		"playNextAll": "Add all to play next",
-		"shuffleAndPlay": "Shuffle and play",
-		"shuffleAndPlayAll": "Shuffle and play all",
-		"playAll": "Play all",
-		"addToQueue": "Add to queue",
-		"removeFromQueue": "Remove from queue",
-		"addSongsToQueue": "Add Songs to queue",
-		"createAQueue": "Create a queue",
-		"info": "Info",
-		"select": "Select",
-		"unselect": "Unselect",
-		"selectAll": "Select all",
-		"unselectAll": "Unselect all",
-		"showAll": "Show all",
-		"cancel": "Cancel",
-		"search": "Search",
-		"help": "Help",
-		"copy": "Copy",
-
-		"sortBy": "Sort By",
-		"filterBy": "Filter By",
-		"moreOptions": "More options",
-		"title": "Title",
-		"suggestion": "Suggestion",
-		"hideSuggestion": "Hide suggestion",
-		"showSuggestion": "Show suggestion",
-		"and": "and",
-		"ignore": "Ignore",
-		"goBack": "Go back",
-		"saveArtwork": "Save artwork",
-		"readMoreAboutTitle": "Read more about the `{{title}}`",
-		"doNotShowThisMessageAgain": "Do not show again.",
-		"artistConflictResolved": "Artist conflict resolved successfully.",
-		"featArtistSuggestionResolved": "Featuring artists suggestion resolved successfully.",
-		"hasInternet": "You are connected to internet.",
-		"noInternet": "You are not connected to internet.",
-		"newUpdateAvailable": "New app update available.",
-		"checkingForUpdates": "Checking for app updates...",
-		"updateCheckError": "Error occurred when checking for app updates.",
-		"updateCheckErrorNoInternet": "$t(common.updateCheckError) $t(common.noInternet)",
-		"optionDisabled": "This option is disabled.",
-		"somethingWentWrong": "Something went wrong.",
-		"details": "Details",
-		"restartApp": "Restart app",
-		"ok": "Okay",
-		"loading": "Loading"
-	},
-
-	"titleBar": {
-		"changeTheme": "Change theme",
-		"goBack": "Go Back (Alt + Left-Arrow)",
-		"goHome": "Go to Home (Alt + Home)",
-		"goForward": "Go Forward (Alt + Right-Arrow)",
-
-		"minimize": "Minimize",
-		"maximize": "Maximize",
-		"close": "Close"
-	},
-
-	"player": {
-		"goToMainPlayer": "Go to Main Player (Ctrl + N)",
-		"openInMiniPlayer": "Open in Mini player (Ctrl + N)",
-		"openInFullScreen": "Open in Fullscreen",
-		"likeDislike": "Like/Dislike (Ctrl + H)",
-		"likeDislikeDisabled": "Like/dislike songs is disabled because the song currently playing is from an unknown source and doesn't support likes.",
-		"prevSong": "Previous song (Ctrl + Left Arrow)",
-		"playPause": "Play/Pause (Space)",
-		"nextSong": "Next song (Ctrl + Right Arrow)",
-		"lyrics": "Lyrics (Ctrl + L)",
-		"shuffle": "Shuffle (Ctrl + S)",
-		"repeat": "Repeat (Ctrl + T)",
-		"muteUnmute": "Mute/Unmute (Ctrl + M)",
-		"currentQueue": "Current queue (Ctrl + Q)",
-		"adjustPlaybackSpeed": "Adjust playback speed",
-		"showCurrentQueue": "Show current queue",
-		"showMiniPlayer": "Show Mini Player",
-		"otherSettings": "Other settings",
-		"upNext": "UP NEXT: ",
-		"closeUpNext": "Close 'UP NEXT'",
-		"by": "by",
-
-		"errorTitle": "An error ocurred in the player.",
-		"errorMessage": "$t(player.errorTitle)<br /> This could be a result of trying to play a corrupted song. <details/>",
-		"noErrorMessage": "No error message generated"
-	},
-
-	"sortTypes": {
-		"aToZ": "A to Z",
-		"zToA": "Z to A",
-		"dateAddedAscending": "Oldest",
-		"dateAddedDescending": "Newest",
-		"releasedYearAscending": "Released year (Ascending)",
-		"releasedYearDescending": "Released year (Descending)",
-		"allTimeMostListened": "Most-listened (All time)",
-		"allTimeLeastListened": "Least-listened (All time)",
-		"monthlyMostListened": "Most-listened (This month)",
-		"monthlyLeastListened": "Least-listened (This month)",
-		"artistNameAscending": "Artist name (A to Z)",
-		"artistNameDescending": "Artist name (Z to A)",
-		"albumNameAscending": "Album name (A to Z)",
-		"albumNameDescending": "Album name (Z to A)",
-		"noOfSongsDescending": "Highest amount of songs",
-		"noOfSongsAscending": "Lowest amount of songs",
-		"blacklistedFolders": "Blacklisted folders",
-		"whitelistedFolders": "Whitelisted folders",
-		"mostLovedDescending": "Most-loved",
-		"mostLovedAscending": "Least-loved",
-		"trackNoAscending": "Track number (Ascending)",
-		"trackNoDescending": "Track number (Descending)",
-		"addedOrder": "Added order"
-	},
-
-	"filterTypes": {
-		"notSelected": "Not Selected",
-		"blacklistedSongs": "Blacklisted songs",
-		"whitelistedSongs": "Whitelisted songs",
-		"favorites": "Favorites",
-		"nonFavorites": "Non-favorites"
-	},
-
-	"equalizerPresets": {
-		"custom": "Custom",
-		"flat": "Flat",
-		"acoustic": "Acoustic",
-		"bassBooster": "Bass booster",
-		"bassReducer": "Bass reducer",
-		"classical": "Classical",
-		"club": "Club",
-		"dance": "Dance",
-		"deep": "Deep",
-		"electronic": "Electronic",
-		"hipHop": "Hip Hop",
-		"jazz": "Jazz",
-		"latin": "Latin",
-		"live": "Live",
-		"loudness": "Loudness",
-		"lounge": "Lounge",
-		"metal": "Metal",
-		"piano": "Piano",
-		"pop": "Pop",
-		"reggae": "Reggae",
-		"rnb": "RnB",
-		"rock": "Rock",
-		"ska": "Ska",
-		"smallSpeakers": "Small speakers",
-		"soft": "Soft",
-		"softRock": "Soft rock",
-		"spokenWord": "Spoken word",
-		"techno": "Techno",
-		"trebleBooster": "Treble booster",
-		"trebleReducer": "Treble reducer",
-		"vocalBooster": "Vocal booster"
-	},
-
-	"song": {
-		"showInFileExplorer": "Show in File Explorer",
-		"artwork": "Song artwork",
-		"selectedSongCount": "{{count}} selected $t(common.song, {\"count\":{{count}}})",
-		"likeSong": "Add to favorites",
-		"unlikeSong": "Remove from favorites",
-		"toggleLikeSongs": "Add/remove songs from favorites",
-		"addToPlaylists": "Add to playlist(s)",
-		"goToAlbum": "Go to album",
-		"editSongTags": "Edit song tags",
-		"reparseSong": "Re-parse song",
-		"blacklistSong_one": "Blacklist song",
-		"blacklistSong_other": "Blacklist songs",
-		"deblacklist": "Restore from blacklist",
-		"delete": "Delete from system",
-		"playingNext": "Playing next",
-		"playingNow": "Playing now",
-		"blacklisted": "Blacklisted",
-		"likedThisSong": "You liked this song",
-		"dislikedThisSong": "You didn't like this song"
-	},
-
-	"artist": {
-		"playAllSongs": "Play all songs",
-		"toggleLikeArtists": "Add/remove artists from favorites",
-		"likeArtist": "Add artist to favorites",
-		"dislikeArtist": "Remove artist from favorites",
-		"selectedArtistCount": "{{count}} selected $t(common.artist, {\"count\":{{count}}})"
-	},
-
-	"folder": {
-		"toggleBlacklistFolder": "Toggle blacklist folder",
-		"blacklistFolder": "Blacklist folder",
-		"selectedFolderCount": "{{count}} selected $t(common.folder, {\"count\":{{count}}})",
-		"selectedParentFolderCount_one": "{{count}} selected parent folder",
-		"selectedParentFolderCount_other": "{{count}} selected parent folders",
-		"directoryCount_one": "{{count}} directory",
-		"directoryCount_other": "{{count}} directories",
-		"selectedDirectoryCount_one": "{{count}} selected directory",
-		"selectedDirectoryCount_other": "{{count}} selected directories"
-	},
-
-	"playlist": {
-		"changeArtwork": "Change artwork",
-		"addArtwork": "Add artwork",
-		"playlistArtworkUpdateSuccess": "Updated playlist artwork successfully.",
-		"renamePlaylist": "Rename playlist",
-		"exportPlaylist": "Export playlist",
-		"importSongs": "Import songs from M3U8",
-		"deleteSelectedPlaylists": "Delete selected playlist(s)",
-		"deletePlaylist_one": "Delete playlist",
-		"deletePlaylist_other": "Delete playlists",
-		"selectedPlaylistCount": "{{count}} selected $t(common.playlist, {\"count\":{{count}}})",
-		"empty": "Seems like this playlist is empty."
-	},
-
-	"album": {
-		"selectedAlbumCount": "{{count}} selected $t(common.album, {\"count\":{{count}}})"
-	},
-
-	"genre": {
-		"selectedGenreCount": "{{count}} selected $t(common.genre, {\"count\":{{count}}})"
-	},
-
-	"homePage": {
-		"empty": "There's nothing here..",
-		"emptyDescription": "It seems like you haven't added any music folders to your library yet.",
-		"loading": "Hold on. We are getting everything ready for you...",
-		"listenMoreToShowMetrics": "Listen to more songs to show additional metrics.",
-
-		"recentlyAddedSongs": "Recently added songs",
-		"recentlyPlayedSongs": "Recently played songs",
-		"recentArtists": "Recent artists",
-		"mostLovedSongs": "Most-loved songs",
-		"mostLovedArtists": "Most-loved artists",
-
-		"openSongsWithNewestSortOption": "Opens 'Songs' with 'Newest' sort option.",
-		"openPlaybackHistory": "Opens 'History' playlist with 'addedOrder' sort option",
-		"openFavoritesWithAllTimeMostListenedSortOption": "Opens 'Favorites' playlist with 'AllTimeMostListened' sort option",
-
-		"noSongsAvailable": "No songs available",
-		"stayCalm": "Stay calm",
-		"favoritesAndRecaps": "Favorites and Recaps"
-	},
-
-	"searchPage": {
-		"addFolder": "Add folder",
-		"enablePredictiveSearch": "Enable predictive search",
-		"disablePredictiveSearch": "Disable predictive search",
-		"searchForAnything": "Search for anything",
-		"searchForAnythingInLibrary": "Search for anything in your library",
-		"separateKeywords": "Use ' ; ' to separate keywords while searching.",
-		"allFilter": "All",
-		"mostRelevant": "Most relevant",
-		"resultCount_one": "{{count}} result",
-		"resultCount_other": "{{count}} results",
-		"resultAndVisibleCount_other": "{{count}} results ($t(common.shownWithCount, {\"count\":{{noVisible}}}))",
-		"noResults": "There's nothing that matches with what you're looking for.",
-		"recentSearchResultTooltipLabel": "Search for '{{value}}'",
-		"showingResultsFor": "Showing results for <span>'{{query}}'</span>",
-		"showingResultsForWithFilter": "Showing results for <span>'{{query}}'</span> on <span>{{filter}}</span>",
-
-		"a": "Search for anything"
-	},
-
-	"songsPage": {
-		"loading": "Hold on. We are getting everything ready for you...",
-		"empty": "There's nothing here.."
-	},
-
-	"artistsPage": {
-		"empty": "There's nothing here..."
-	},
-
-	"foldersPage": {
-		"addFolder": "Add folder",
-		"musicFolders": "Music folders",
-		"empty": "No folders added to your library."
-	},
-
-	"playlistsPage": {
-		"createNewPlaylist": "Create new playlist",
-		"importPlaylist": "Import a playlist",
-		"addPlaylist": "Add a playlist",
-		"removeFromThisPlaylist": "Remove from this playlist",
-		"removeSongFromPlaylistSuccess": "`{{title}}` removed from '{{playlistName}}'this playlist",
-		"createdOn": "Created on {{val, datetime}}",
-		"clearSongHistoryConfirm": "Clear song history",
-		"clearSongHistoryConfirmNotice": "Are you sure you want to clear your song history? This action cannot be undone.",
-		"clearSongHistorySuccess": "Your song history has been cleared successfully.",
-		"empty": "No playlists created yet.",
-
-		"favorites": "Favorites",
-		"history": "History"
-	},
-
-	"albumsPage": {
-		"empty": "There's nothing here..."
-	},
-
-	"genresPage": {
-		"empty": "There's nothing here..."
-	},
-
-	"settingsPage": {
-		"settings": "Settings",
-
-		"appearance": "Appearance",
-		"changeTheme": "Change the theme of the application to your preference.",
-		"lightTheme": "Light theme",
-		"darkTheme": "Dark theme",
-		"systemTheme": "System theme",
-
-		"enableImageBasedDynamicThemes": "Enable Dynamic Themes",
-		"enableImageBasedDynamicThemesDescription": "Change app theme dynamically based on the theme of the current playing song cover image",
-
-		"language": "Language",
-		"languageDescription": "Select the language you want Nora to be displayed in.",
-
-		"audioPlayback": "Audio playback",
-		"showRemainingSongDuration": "Show remaining song duration",
-		"showRemainingSongDurationDescription": "Shows the remaining duration of the song instead of the default song duration.",
-		"playbackRate": "Playback speed",
-		"changePlaybackRate": "Change the default playback speed of the player.",
-		"resetPlaybackRate": "Reset to 1x",
-		"seekbarScrollInterval": "Change the increment amount when scrolled over audio seek bar and volume seek bar.",
-		"second": "second",
-		"second_other": "seconds",
-
-		"accounts": "Accounts",
-		"integrateLastFm": "Integrate Last.fm with Nora.",
-		"lastFmLogo": "LastFM logo",
-		"lastFmConnected": "LastFM connected",
-		"lastFmNotConnected": "LastFM not connected",
-		"loggedInAs": "Logged in as",
-		"lastFmDescription1": "Connect with Last.fm to enable Scrobbling.",
-		"lastFmDescription2": "Scrobbling is a way to send information about the music a user is listening to.",
-		"lastFmDescription3": "Whenever you listen to a song, Last.fm “Scrobbles” that song and adds it to your account.",
-		"lastFmDescription4": "This feature requires an internet connection.",
-		"authenticateAgain": "Authenticate again",
-		"loginInBrowser": "Login via browser",
-		"scrobblingDescription": "Enable Last.fm Scrobbling to send data related to how you listen to songs.",
-		"enableScrobbling": "Enable Last.fm Scrobbling",
-		"sendFavoritesToLastFmDescription": "Send favorites data to Last.fm when you like/dislike songs.",
-		"sendFavoritesToLastFm": "Send favorites data",
-		"sendNowPlayingToLastFmDescription": "Send the currently playing song data to Last.fm automatically when you start to play a song.",
-		"sendNowPlayingToLastFm": "Send currently playing song data",
-		"enableDiscordRpcDescription": "Integrate Discord Rich Presence with Nora",
-		"enableDiscordRpc": "Enable Discord Rich Presence",
-
-		"doNotSaveLyricsAutomatically": "Don't save lyrics automatically",
-		"syncedLyricsOnly": "Synced lyrics only",
-		"saveEitherLyrics": "Synced or unsynced lyrics",
-		"lyrics": "Lyrics",
-		"enableMusixmatchLyricsDescription": "Enable Musixmatch Lyrics, which provides synced and unsynced lyrics for your songs on-demand.",
-		"musixmatchDisclaimerNotice": "Enabling and using this feature means that you agree to, and accept the <Button>Musixmatch Lyrics Disclaimer</Button>.",
-		"editMusixmatchSettings": "Edit Musixmatch settings",
-		"enableMusixmatch": "Enable Musixmatch Lyrics",
-		"musixmatchEnabled": "Musixmatch Lyrics is enabled",
-		"saveLyricsAutomaticallyDescription": "Select an option to save song lyrics automatically when fetched in lyrics page.",
-		"saveLyricsAutomaticallyInfo": "Automatically downloaded lyrics will be saved after the current song is finished to prevent any corruption from happening.",
-		"saveLyricsInLrcFilesDescription": "Enable saving lyrics in LRC files for songs that support metadata editing. Nora will save lyrics in an LRC file if the song file doesn't support metadata editing.",
-		"saveLyricsInLrcFiles": "Also save lyrics in LRC files for supported songs",
-		"autoTranslateLyricsDescription": "Enable automatic translation of lyrics to your selected language. Lyrics will be automatically translated even if the lyrics have the same language as your selected language.",
-		"autoTranslateLyrics": "Auto translate lyrics",
-		"autoConvertLyricsDescription": "Enable automatic conversion of supported lyrics to Latin characters. Currently, Nora supports converting Japanese, Chinese, and Korean lyrics to their respective Romanization systems.",
-		"autoConvertLyrics": "Auto convert lyrics",
-		"lrcFileCustomSaveLocationDescription": "Select a custom location to save LRC files of songs if you don't want to save them in the same folder as the relative song.",
-		"selectedCustomLocation": "Selected custom location",
-		"setCustomLocation": "Set custom location",
-
-		"equalizer": "Equalizer",
-		"reset": "Reset",
-
-		"defaultPage": "Default page",
-		"changeDefaultPageDescription": "Change the default page you want to see when you open the app.",
-
-		"preferences": "Preferences",
-		"songIndexingDescription": "Enables indexing of songs in pages, adding a number to each song in the Songs tab.",
-		"enableSongIndexing": "Enable song indexing",
-		"showTrackNumberAsSongIndexDescription": "Show track number in front of the song when in albums page.",
-		"showTrackNumberAsSongIndex": "Show track number as song index",
-		"showArtistArtworkNearSongControlsDescription": "Shows artist artworks next to the artist names near the title of the song on the song controls panel.",
-		"showArtistArtworkNearSongControls": "Show available artist artworks next to their name (bottom left).",
-		"disableBackgroundArtworksDescription": "Disables the large artworks shown on the background of some pages.",
-		"disableBackgroundArtworks": "Disable background artworks",
-		"playlistArtworksDescription": "Change the behavior of artworks made from song covers.",
-		"enablePlaylistArtworks": "Enable artworks made from song covers on playlists",
-		"shuffleArtworkFromSongCovers": "Enable shuffling the artwork made from song covers. (The artworks shuffle each time a page refresh happens.)",
-
-		"accessibility": "Accessibility",
-		"reducedMotionDescription": "Removes animation that appears in the app. This will also reduce the smoothness of the app.",
-		"enableReducedMotion": "Enable reduced motion",
-
-		"performance": "Performance",
-		"removeAnimationOnBatteryDescription": "Removes the animations in the app when your system is on battery power.",
-		"removeAnimationOnBattery": "Remove animations when on battery power.",
-		"allowToPreventScreenSleepingDescription": "Allow Nora to prevent the display from going to sleep in situations with no user activity like displaying lyrics.",
-		"allowToPreventScreenSleeping": "Allow preventing the display from going to sleep.",
-
-		"startupAndWindowCustomization": "Startup and Windows settings",
-		"autoLaunchAtStartDescription": "Enabling this setting will automatically launch Nora when you login to your computer.",
-		"autoLaunchAtStart": "Auto launch at startup",
-		"hideWindowAtStartDescription": "Configure whether Nora should be visible when it's started up.",
-		"hideWindowAtStart": "Launch Nora in the System Tray on startup",
-		"hideWindowOnCloseDescription": "Configure how Nora should behave when you click the close button.",
-		"hideWindowOnClose": "Hide Nora to the System Tray when the close button is clicked.",
-
-		"storage": "Storage",
-		"storageDescription": "See how Nora manages your library and utilizes your storage.",
-
-		"fullStorageSpace": "Full storage usage",
-		"fullStorageOutOfUsage": "{{value}} out of {{total}}",
-		"freeSpace": "Free space",
-		"otherApplications": "Other applications",
-		"artworkCache": "Artwork cache",
-		"tempArtworkCache": "Temp artwork cache",
-		"databaseData": "Database",
-		"songsData": "Song data",
-		"artistsData": "Artist data",
-		"albumsData": "Album data",
-		"playlistsData": "Playlist data",
-		"palettesData": "Palette data",
-		"genresData": "Genre data",
-		"appLogs": "Application logs",
-		"userData": "User data",
-		"internalAppFiles": "Internal application files",
-		"storageUseForLibraryData": "Storage usage for library data",
-		"otherAppFiles": "Other application files",
-		"generated": "Generated",
-		"generateStorageMetrics": "Generate storage metrics",
-		"generateStorageMetricsAgain": "Generate storage metrics again",
-		"noStorageMetrics": "Seems like you haven't generated storage metrics yet.",
-		"storageMetricsGenerationDisclaimer": "Generating storage metrics is a relatively demanding computational task, this means Nora may become unresponsive temporarily. Please be patient...",
-		"storageMetricsGenerationError": "Seems like something went wrong on our end. Please report this to the developer.",
-
-		"advanced": "Advanced",
-		"saveVerboseLogsDescription": "Save verbose logs for debugging purposes. This will increase the size of the logs.",
-		"saveVerboseLogs": "Save verbose logs",
-
-		"about": "About",
-		"releasedOn": "Released on {{val, datetime}}",
-		"noraWebsite": "Nora's official website",
-		"noraDiscordServer": "Nora's official Discord server",
-		"noraGithubRepo": "Nora's Github repository",
-		"noraGithubIssues": "Nora's Github issues",
-		"noraLocalizationStatus": "Nora localization status",
-		"noraDescription": "Nora is an elegant music player built using Electron and React.",
-		"noraInspiration": "Inspired by <Hyperlink>Oto Music for Android</Hyperlink> by Piyush Mamidwar.",
-		"otoMusicOnPlayStore": "Oto Music for Android on the Play Store",
-		"noraLicenseNotice": "This product is licensed under the <Button>MIT licence.</Button>",
-		"appLicense": "App license",
-		"releaseNotes": "Release notes",
-		"openSourceLicenses": "Open-source licenses",
-		"openLogFile": "Open log file",
-		"openDevtools": "Open dev-tools",
-		"resyncLibrary": "Resync library",
-		"generatePalettes": "Generate palettes",
-		"appShortcuts": "App shortcuts",
-
-		"resetApp": "Reset app",
-		"clearOptionalData": "Clear optional data",
-		"clearHistory": "Clear history",
-		"confirmSongHistoryDeletion": "Clear song history",
-		"songHistoryDeletionDisclaimer": "Are you sure you want to clear your song history? This action cannot be undone.",
-		"songHistoryDeletionSuccess": "Your song history has been cleared successfully.",
-		"exportAppData": "Export app data",
-		"importAppData": "Import app data",
-		"createIssueOnNoraGithubRepo": "create an issue on $t(settingsPage.noraGithubRepo)",
-		"contact": "If you have any feedback about bugs, feature requests (etc.) about the app, please <Hyperlink>$t(settingsPage.createIssueOnNoraGithubRepo)</Hyperlink>",
-		"emailContact": "or contact me through my email.",
-		"loveNora": "Made with <span>❤</span> by <Hyperlink>Sandakan Nipunajith</Hyperlink>.",
-		"sandakanGithubProfile": "Sandakan's Github profile",
-		"beautifulSriLanka": "Beautiful Sri Lanka"
-	},
-
-	"artistInfoPage": {
-		"likeArtist": "Like {{name}}",
-		"dislikeArtist": "Dislike {{name}}",
-		"appearsInAlbums": "Appears in albums",
-		"appearsInSongs": "Appears in songs",
-		"similarArtistsInLibrary": "Similar artists in the library",
-		"otherSimilarArtists": "Other similar artists",
-		"viewInLastFm": "View `{{name}}` in Last.fm"
-	},
-
-	"albumInfoPage": {
-		"unavailableTracks": "Unavailable Tracks of this Album"
-	},
-
-	"currentQueuePage": {
-		"queue": "Currently Playing Queue",
-		"folderWithName": "{{name}} Folder",
-		"enableAutoScrolling": "Enable Auto Scrolling",
-		"disableAutoScrolling": "Disable Auto Scrolling",
-		"scrollToCurrentPlayingSong": "Scroll to currently playing song",
-		"shuffleQueue": "Shuffle Queue",
-		"queueShuffleSuccess": "Queue shuffled successfully.",
-		"clearQueue": "Clear Queue",
-		"queueCleared": "Queue cleared.",
-		"durationRemaining": "{{duration}} remaining",
-		"empty": "Queue is empty."
-	},
-
-	"lyricsEditingPage": {
-		"lyricsText": "Lyrics Text",
-		"startInSeconds": "Start in seconds",
-		"endInSeconds": "End in seconds",
-		"fromTo": "From {{start}} to {{end}}",
-		"deleteLine": "Delete Line",
-		"addLineAbove": "Add Line Above",
-		"addLineBelow": "Add Line Below",
-		"addInstrumentalLineBelow": "Add Instrumental Line Below",
-		"editLine": "Edit Line",
-		"finishEditing": "Finish Editing",
-		"resetLyrics": "Reset Lyrics",
-		"resetLyricsConfirm": "Are your sure that you want to Reset Lyrics?",
-		"resetLyricsConfirmMessage": "<p>You will lose <span>recent lyrics line modifications</span> and <span>start/end synchronization data</span> if you continue this action.</p> <br/> <p>This action is irreversible.</p>",
-		"incorrectSongTitle": "Not in the right song",
-		"incorrectSongMessage": "To start editing, play `{{title}}` song.",
-		"lyricsEditor": "Lyrics Editor",
-		"playbackSpeed": "Speed",
-		"playbackTime": "Time",
-		"offsetWithCount": "{{count}} offset",
-		"saveLyrics": "Save Lyrics",
-		"stopAndEditLyrics": "Stop and Edit Lyrics",
-		"playLyrics": "Play Lyrics",
-		"configure": "Configure"
-	},
-
-	"lyricsPage": {
-		"noLyrics": "Lyrics not found.",
-		"noLyricsDescription": "We couldn't find any lyrics for this song. You can add your own in the Tag Editor.",
-		"noSyncedLyrics": "No synced lyrics found.",
-		"noSyncedLyricsDescription": "We couldn't find any synced lyrics for this song.",
-		"noOnlineLyrics": "No online lyrics found.",
-		"noOfflineLyrics": "No offline lyrics found.",
-		"noSavedLyrics": "No saved lyrics found.",
-		"onlineLyricsRefreshFailed": "Failed to refresh online lyrics.",
-		"offlineLyricsForSong": "Offline lyrics for `{{title}}`",
-		"onlineLyricsForSong": "Online lyrics for `{{title}}`",
-		"editLyrics": "Edit lyrics in the editor",
-		"translateLyrics": "Translate lyrics",
-		"romanizeLyrics": "Romanize Japanese lyrics",
-		"convertLyricsToPinyin": "Convert Chinese lyrics to Pinyin",
-		"convertLyricsToRomaja": "Convert Korean lyrics to Romaja",
-		"resetLyrics": "Reset Lyrics",
-		"showOnlineLyrics": "Show online lyrics",
-		"refreshOnlineLyrics": "Refresh online lyrics",
-		"showSavedLyrics": "Show saved lyrics",
-
-		"lyricsLoading": "Looking for lyrics",
-		"lyricsLoadingDescription": "Hang on... We're looking everywhere...",
-		"noInternet": "No internet connection",
-		"noInternetDescription": "There are no offline lyrics for this song. You need an internet connection to check for online lyrics.",
-		"lyricsProvidedBy": "Lyrics provided by <Hyperlink/>",
-		"lyricsTranslatedBy": "Lyrics translated using Google Translate"
-	},
-
-	"songInfoPage": {
-		"listensCount": "{{count}} listens",
-		"listeningActivityInLastMonths": "Listening activity in the Last {{count}} Months",
-		"similarTracksInLibrary": "Similar tracks in your library",
-		"otherSimilarTracks": "Other similar tracks",
-		"additionalSongInfo": "Additional song information",
-		"allTimeListens": "All time listens",
-		"listensThisMonth": "Listens this month",
-		"listensThisYear": "Listens this year",
-		"totalSongSkips": "Total song skips",
-		"fullSongListens": "Full song listens",
-		"mostSoughtPosition": "Most sought position",
-		"mostSoughtFrequency": "Most sought frequency",
-		"lovedSong": "You loved this song",
-		"unlovedSong": "You didn't like this song",
-		"byArtists": " <By>by</By> <span>{{val, list}}</span>"
-	},
-
-	"songTagsEditingPage": {
-		"editArtwork": "Edit artwork",
-		"removeArtwork": "Remove artwork",
-		"lyricsIncluded": "Lyrics included",
-		"addToMetadata": "Add to metadata",
-		"customizeMetadata": "Customize metadata",
-		"songMetadataEditor": "Song metadata editor",
-		"searchMetadataOnInternet": "Search metadata on the internet",
-		"saveTags": "Save Metadata Tags",
-		"updateAddedToBeSavedLater": "Metadata updates of currently playing songs will be saved after the song playback is finished.",
-		"pendingUpdateAvailable": "A metadata update of this song is pending to be saved.",
-		"saveTagsNotSupportedTitle": "Not Supported",
-		"saveTagsNotSupportedDescription": "<P1>Nora currently doesn't support editing song metadata in <Format/> format.</P1><P2>Currently only <SupportedFormat/> format is supported.",
-		"albumArtistNotMentioned": "Song is already part of the album named `{{title}}` but its artist(s) '{{artists}}' is/are not specified as the album artist(s) for this song.",
-		"songAlbumArtistMismatch": "Selected album artist(s) '{{albumArtists}}' don't match with the selected album '{{albumTitle}}' artist(s) '{{songAlbumArtists}}'.",
-		"searchForArtists": "Search for artists here",
-		"searchForAlbums": "Search for albums here",
-		"searchForGenres": "Search for genres here",
-		"addNewArtist": "Add new artist `{{name}}`",
-		"addNewAlbum": "Add new album `{{name}}`",
-		"addNewGenre": "Add new genre `{{name}}`",
-		"albumName": "Album name",
-		"songArtists": "Song artists",
-		"songName": "Song name",
-		"composer": "Composer",
-		"syncedLyricsFetchFailed": "Failed to fetch synced lyrics.",
-		"lyricsEnhancedSynced": "Lyrics are enhanced synced.",
-		"lyricsNotEnhancedSynced": "Lyrics are not enhanced synced.",
-		"enhancedLyricsSupported": "Enhanced synced lyrics supported.",
-		"readMoreAboutLrc": "$t(common.readMoreAboutTitle, {\"title\": \"LRC format\"})",
-		"avoidUnsyncedOnSyncedLyricsTab": "Avoid entering unsynchronized lyrics in the synchronized lyrics tab.",
-		"avoidSyncedOnUnsyncedLyricsTab": "Avoid entering synchronized lyrics in the unsynchronized lyrics tab.",
-		"pendingLyricsSavesAvailable": "There are pending lyrics to be saved to this song. They will be saved and visible here after the current song is finished playing.",
-		"downloadLyrics": "Download lyrics",
-		"downloadSyncedLyrics": "Download synced lyrics",
-		"musixmatchNotEnabled": "'You have to enable Musixmatch Lyrics from Settings to use this feature."
-	},
-
-	"miniPlayer": {
-		"alwaysOnTopEnabled": "Always on top: ON",
-		"alwaysOnTopDisabled": "Always on top: OFF"
-	},
-
-	"time": {
-		"second_one": "second",
-		"second_other": "seconds",
-		"minute_one": "minute",
-		"minute_other": "minutes",
-		"hour_one": "hour",
-		"hour_other": "hours",
-		"day_one": "day",
-		"day_other": "days",
-		"month_one": "month",
-		"month_other": "months",
-		"year_one": "year",
-		"year_other": "years",
-		"secondWithCount": "{{count}} $t(time.second, {\"count\":{{count}}})",
-		"minuteWithCount": "{{count}} $t(time.minute, {\"count\":{{count}}})",
-		"hourWithCount": "{{count}} $t(time.hour, {\"count\":{{count}}})",
-		"dayWithCount": "{{count}} $t(time.day, {\"count\":{{count}}})",
-		"monthWithCount": "{{count}} $t(time.month, {\"count\":{{count}}})",
-		"yearWithCount": "{{count}} $t(time.year, {\"count\":{{count}}})"
-	},
-
-	"elapsedTime": {
-		"second_one": "{{count}} second ago",
-		"second_other": "{{count}} seconds ago",
-		"minute_one": "{{count}} minute ago",
-		"minute_other": "{{count}} minutes ago",
-		"hour_one": "{{count}} hour ago",
-		"hour_other": "{{count}} hours ago",
-		"day_one": "{{count}} day ago",
-		"day_other": "{{count}} days ago",
-		"month_one": "{{count}} month ago",
-		"month_other": "{{count}} months ago",
-		"year_one": "{{count}} year ago",
-		"year_other": "{{count}} years ago"
-	},
-
-	"month": {
-		"january": "January",
-		"february": "February",
-		"march": "March",
-		"april": "April",
-		"may": "May",
-		"june": "June",
-		"july": "July",
-		"august": "August",
-		"september": "September",
-		"october": "October",
-		"november": "November",
-		"december": "December"
-	},
-
-	"data": {
-		"byteWithCount_one": "{{count}} byte",
-		"byteWithCount_other": "{{count}} bytes"
-	},
-
-	"sideBar": {
-		"home": "Home",
-		"search": "Search"
-	},
-
-	"renamePlaylistPrompt": {
-		"renamePlaylistWithName": "Rename `{{name}}` playlist",
-		"playlistName": "Playlist name"
-	},
-
-	"newPlaylistPrompt": {
-		"addPlaylistSuccess": "Playlist added successfully.",
-		"playlistNameEmpty": "Playlist name is required",
-		"addNewPlaylist": "Add new playlist"
-	},
-
-	"confirmDeletePlaylistsPrompt": {
-		"playlistsDeletedWithCount": "$t(common.playlistWithCount, {\"count\":{{count}}}) deleted.",
-		"confirmPlaylistDeleteWithCount": "Confirm deleting $t(common.playlistWithCount, {\"count\":{{count}}})",
-		"message_one": "Removing this playlist will remove the connection between songs that you organized into this playlist. You won't be able to access this playlist again if you decide to delete it.",
-		"message_other": "Removing these playlists will remove the connection between songs that you organized into these playlists. You won't be able to access these playlists again if you decide to delete it.",
-		"modificationNotice": "Performing this action will affect these files: "
-	},
-
-	"resetAppConfirmationPrompt": {
-		"confirmAppReset": "Confirm app reset",
-		"message": "Resetting the app removes all user data, including data related to songs, favorites, preferences, applied settings, etc., but NOT the songs themselves. Please note that this action is <span>IRREVERSIBLE</span>.",
-		"restartAfterReset": "Nora will restart after the reset.",
-		"systemPlaylistsRemovalProhibited": "You cannot remove playlists like History or Favorites."
-	},
-
-	"addSongsToPlaylistsPrompt": {
-		"songsAddedToPlaylists": "Added $t(common.songWithCount, {\"count\":{{count}}}) to $t(common.playlistWithCount, {\"count\":{{playlistCount}}})",
-		"selectPlaylistsToAdd": "Select playlists to add $t(common.songWithCount, {\"count\":{{count}}})",
-		"duplicationNotice": "When adding multiple songs to playlists, songs that are already in selected playlists will be ignored."
-	},
-
-	"blacklistSongConfirmPrompt": {
-		"title": "Confirm blacklisting $t(common.songWithCount, {\"count\":{{count}}}) from the library",
-		"message_one": "You are about to blacklist this song from the library. You can restore it again by right-clicking it and clicking '$t(song.deblacklist)'. Your data related to this song won't be affected by this action.",
-		"message_other": "You are about to blacklist these songs from the library. You can restore them again by right-clicking and clicking '$t(song.deblacklist)'. Your data related to these songs won't be affected by this action.",
-		"effectTitle": "What blacklisting a song does",
-		"effect1": "Will appear greyed-out in the library with a '<span/>' symbol.",
-		"effect2": "Won't be added to the queue automatically, not even through <span>'$t(common.shuffleAndPlay)'</span> or<span>'$t(common.playAll)'</span>, unless you explicitly add them.",
-		"effect3": "Can still be played by double-clicking, or by using either <span>'$t(common.play)'</span> or <span>'$t(common.playNext)'.</span>",
-		"songsBlacklisted": "$t(common.songWithCount, {\"count\":{{count}}}) blacklisted and removed from the library"
-	},
-
-	"blacklistFolderConfirmPrompt": {
-		"title": "Confirm blacklisting $t(common.folderWithCount, {\"count\":{{count}}}) from the library",
-		"message_one": "You are about to blacklist this folder. You can restore it again from the Folders page by right-clicking and selecting '$t(song.deblacklist)'. Your data related to this folder won't be affected by this action.",
-		"message_other": "You are about to blacklist these folders. You can restore them again from the Folders page by right-clicking and selecting '$t(song.deblacklist)'. Your data related to these folders won't be affected by this action.",
-		"effectTitle": "What blacklisting a folder does",
-		"effect1": "Will appear greyed out in the library with '<span/>' symbol.",
-		"effect2": "Songs linked to this folder will also be blacklisted.",
-		"effectTitle2": "What happens to songs linked to a blacklisted folder",
-		"folderBlacklisted": "$t(common.folderWithCount, {\"count\":{{count}}}) blacklisted."
-	},
-
-	"deleteSongFromSystemConfirmPrompt": {
-		"title_one": "Delete `{{title}}` from system",
-
-		"title_other": "Delete $t(common.songWithCount, {\"count\":{{count}}}) from system",
-		"permanentlyDeleteFromSystem": "Permanently delete from the system",
-		"message_one": "You will lose this song from your system and may not be able to recover it again if you select '$t(deleteSongFromSystemConfirmPrompt.permanentlyDeleteFromSystem)' from system option.",
-		"message_other": "You will lose these songs from your system and may not be able to recover them again if you select '$t(deleteSongFromSystemConfirmPrompt.permanentlyDeleteFromSystem)' from system option.",
-		"modificationNotice": "Proceeding this action affects these files :",
-		"deleteSong": "Delete song",
-		"songPermanentlyDeleted": "$t(common.songWithCount, {\"count\":{{count}}}) removed from the system.",
-		"songMovedToBin": "$t(common.songWithCount, {\"count\":{{count}}}) moved to the recycle Bin."
-	},
-
-	"addMusicFoldersPrompt": {
-		"title": "Select folders to add",
-		"emptyMessage1": "Seems like you didn't select any folders.",
-		"emptyMessage2": "Choose some folders from your system, and they will appear here for you to further customize them.",
-		"chooseFolders": "Choose folders",
-		"addSelectedFolders": "Add selected folders",
-		"noFoldersSelected": "No folders selected. (Must have one parent folder)"
-	},
-
-	"removeFolderConfirmationPrompt": {
-		"title": "Confirm to remove `{{folderName}}` folder",
-		"message": "Are you sure that you want to remove this folder from the music library? This will remove all the data related to this folder including songs data from the music library. The files on your system will remain untouched.",
-		"removeFolder": "Remove folder"
-	},
-
-	"lyricsEditorHelpPrompt": {
-		"title": "How to use Nora's lyrics editor",
-		"subTitle1": "How to start using the editor?",
-		"subTitle1Message": " <ol><li>Play the song that you are trying to edit lyrics of. (If you are not in the correct song, app will prevent adding incorrect metadata to lyrics lines.)</li><li>Click on the page area to get focus to the page. (Page focus is required for the page-specific keyboard shortcuts to work.)</li><li>Start the song from the begining. If you want more control over the playback, set to repeat the current song.</li><li>When the voice of the song is saying the lyrics line, press <ShortcutButton>$t(appShortcutsPrompt.enterKey)</ShortcutButton> to highlight the next lyrics line and add the current time to start tag.</li><li>Continue until the last lyrics line.</li></ol>",
-		"subTitle2": "What are the keyboard shortcuts I can use in the Lyrics Editor?",
-		"subTitle2Message": "Go to the <Button>Shortcuts Prompt</Button> to see the relevant shortcuts that can be used in the Lyrics Editor.",
-		"subTitle3": "I missed a lyrics line?",
-		"subTitle3Message": "<ol><li>Pause the song.</li><li>Locate the relevant lyrics line.</li><li>Click the <ShortcutButton>Edit</ShortcutButton> button below that line and make the necessary modifications.</li><li>After the modifications, click <ShortcutButton>$t(lyricsEditingPage.finishEditing)</ShortcutButton> to complete the modifications.</li></ol>",
-		"subTitle4": "I added wrong data to the wrong line?"
-	},
-
-	"lyricsEditorSavePrompt": {
-		"lyricsUpdateSuccess": "Lyrics successfully updated.",
-		"saveEditedLyrics": "Save edited lyrics",
-		"copyLyrics": "Copy lyrics",
-		"saveLyricsToSong": "Save lyrics to song",
-		"saveLyricsNotSupported": "Nora currently doesn't support saving lyrics to songs in '{{format}}' audio format.",
-		"saveLyricsFormatInfo": "* Lyrics are saved in <Hyperlink>LRC format</Hyperlink>.",
-		"readAboutLrcFormat": "Read more about the LRC format"
-	},
-
-	"lyricsEditorSettingsPrompt": {
-		"lyricsEditorSettings": "Lyrics editor settings",
-		"editNextAndCurrentStartAndEndTagsAutomaticallyDescription": "Change the start time tag of the next lyrics line when you edit the end time tag of the current lyrics line and vice versa automatically.",
-		"editNextAndCurrentStartAndEndTagsAutomatically": "Edit next line's start tag with the current line's end tag and vice versa automatically.",
-		"lyricOffsetInputDescription": "Select a negative or positive offset to add to lyrics lines when editing them automatically.",
-		"lyricOffsetInput": "Offset (+ or -)"
-	},
-
-	"pageFocusPrompt": { "pageNotFocused": "Page not focused." },
-
-	"releaseNotesPrompt": {
-		"latestVersion": "You have the latest version.",
-		"oldVersion": "<br/><span>You do not have the latest version.</span> <Hyperlink>Update now</Hyperlink>",
-		"outdatedChangelogNotice": "You may be viewing an outdated changelog.",
-		"versionCheckError": "<br/><span>Failed to check for new updates. Something is wrong in our end.<div>$t(releaseNotesPrompt.outdatedChangelogNotice)</div></span>",
-		"versionCheckNetworkError": "<br/><span> We couldn't check for new updates. Check you network connection and try again.<div>$t(releaseNotesPrompt.outdatedChangelogNotice)</div></span>",
-		"noraReleases": "Nora releases",
-		"changelog": "Changelog",
-		"doNotRemindThisVersionUpdate": "Do not remind me again about this version of the app.",
-		"current": "Current",
-		"latest": "Latest",
-		"newFeaturesAndUpdates": "New features and updates",
-		"fixesAndImprovements": "Fixes and improvements",
-		"issuesAndBugs": "Known issues and bugs",
-		"developerUpdates": "Developer updates"
-	},
-
-	"appShortcutsPrompt": {
-		"inAppShortcuts": "In app shortcuts",
-
-		"mediaPlayback": "Media playback",
-		"playPause": "Play / Pause",
-		"toggleMute": "Toggle mute",
-		"nextSong": "Next song",
-		"prevSong": "Previous song",
-		"tenSecondsForward": "10 seconds forward",
-		"tenSecondsBackward": "10 seconds backward",
-		"upVolume": "Increase volume",
-		"downVolume": "Decrease volume",
-		"toggleShuffle": "Toggle queue shuffle",
-		"toggleRepeat": "Toggle queue repeat",
-		"toggleFavorite": "Toggle favorite",
-		"upPlaybackRate": "Increase playback rate by 0.05x",
-		"downPlaybackRate": "Decrease playback rate by 0.05x",
-		"resetPlaybackRate": "Reset playback rate to 1x",
-
-		"navigation": "Navigation",
-		"goHome": "Go to Home",
-		"goBack": "Go back",
-		"goForward": "Go forward",
-		"openMiniPlayer": "Open Mini Player",
-		"goToLyrics": "Go to Lyrics",
-		"goToQueue": "Go to Current queue",
-		"goToSearch": "Go to Search",
-
-		"selections": "Selections",
-		"selectMultipleItems": "Select multiple items",
-
-		"lyrics": "Lyrics",
-		"playNextLyricsLine": "Play the next lyrics line",
-		"playPrevLyricsLine": "Play the previous lyrics line",
-
-		"lyricsEditor": "Lyrics editor",
-		"selectNextLyricsLine": "Select the next lyrics line",
-		"selectPrevLyricsLine": "Select the previous lyrics line",
-		"selectCustomLyricsLine": "Select a custom lyrics line",
-
-		"otherShortcuts": "Other shortcuts",
-		"toggleTheme": "Toggle app theme",
-		"toggleMiniPlayerAlwaysOnTop": "Toggle Mini Player always on top",
-		"reload": "Reload",
-		"openDevtools": "Open devtools",
-		"openAppShortcutsPrompt": "Open App Shortcuts prompt",
-
-		"enterKey": "Enter",
-		"spaceKey": "Space",
-		"ctrlKey": "Ctrl",
-		"shiftKey": "Shift",
-		"altKey": "Alt",
-		"homeKey": "Home",
-		"rightArrowKey": "Right arrow",
-		"leftArrowKey": "Left arrow",
-		"upArrowKey": "Up arrow",
-		"downArrowKey": "Down arrow",
-
-		"mouseClick": "Mouse click",
-		"doubleClick": "Double-click"
-	},
-
-	"clearLocalStoragePrompt": {
-		"title": "Confirm clearing local storage data",
-		"description": "This process will clear any corrupted local storage data in Nora and revert it back to the default settings.",
-		"effect": "<p>Proceeding this action will affect the following data: </p><ul><li>Most preference settings in Nora</li><li>Playback settings such as currently playing song, volume etc.</li><li>Current queue data</li><li>Ignored suggestions data such as featuring artists, separate artists and duplicates</li><li>Page sorting data</li><li>Equalizer data</li><li>Lyrics editor settings</li></ul>",
-		"restartNotice": "Nora will restart after the process."
-	},
-
-	"musixmatchDisclaimerPrompt": {
-		"title": "Disclaimer - Musixmatch Lyrics",
-		"message": "<li> Musixmatch Lyrics is added as an evaluation feature to this software and could be removed at any time.</li><li>Nora is in no way affiliated with, authorised, maintained, sponsored or endorsed by Musixmatch Lyrics or any of its affiliates or subsidiaries.</li><li>The maintainers of this application call upon the personal responsibility of its users to use this feature in a fair way, as it is intended to be used by obeying the copyrights implemented by Musixmatch Lyrics.</li>",
-		"implementationNotice": "Implementation from Fashni's <Hyperlink/>.",
-		"hyperlinkTitle": "MxLRC Github repository",
-		"contactAboutComplaints": "If you have any complaints, you can contact me through the Nora Discord server, or through my <Hyperlink>email</Hyperlink>."
-	},
-
-	"musixmatchSettingsPrompt": {
-		"title": "Musixmatch settings",
-		"message": "<li>Musixmatch requires a user token to provide its service properly.</li><li>Musixmatch can sometimes fail to show lyrics due to prolonged use of the service from the same token.</li><li>Follow the guide from <Hyperlink>Spicetify Wiki</Hyperlink> to get a new Musixmatch token.</li>",
-		"showToken": "Show token",
-		"hideToken": "Hide token",
-		"updateToken": "Update token",
-		"tokenUpdateSuccess": "Token updated successfully.",
-		"tokenUpdateFailed": "Failed to update the token.",
-		"tokenMissingCharacters": "TOKEN should be a string with 54 characters. ({{count}} more characters required).",
-		"tokenIncorrectCharacters": "TOKEN should only contain alpha-numeric characters.",
-		"savedTokenAvailableMessage": "<Title><span/> A saved token available.</Title><p> A valid Musixmatch token saved by the user is already available in Nora.</p> <p> You only need to change the token if the service is not functioning properly.</p>"
-	},
-
-	"customizeSelectedMetadataPrompt": {
-		"selected": "Selected",
-		"select": "Select",
-		"title": "Customize downloaded metadata for `{{title}}`",
-		"selectArtwork": "Select an artwork",
-		"noArtworksFound": "No artworks found",
-		"customizeOtherMetadata": "Customize other metadata",
-		"syncedLyricsAvailable": "Synced lyrics available",
-		"unsyncedLyricsAvailable": "Unsynced lyrics available",
-		"addOnlySelected": "Add only selected",
-		"addAll": "Add all"
-	},
-
-	"resetTagsToDefaultPrompt": {
-		"changed": "Changed",
-		"title": "Confirm before resetting song data to default",
-		"description": "Are you sure you want to reset the song data? You will lose the data you edited on this screen.",
-		"resetToDefault": "Reset to default"
-	},
-
-	"songMetadataResultSelectPrompt": {
-		"title": "Results related to <span/>"
-	},
-
-	"errorPrompt": {
-		"title": "An error occurred",
-		"sendErrorInfo": "Please send us <Hyperlink1>feedback</Hyperlink1> to improve the app or <Hyperlink2>create an issue</Hyperlink2> on Github."
-	},
-
-	"openLinkConfirmPrompt": {
-		"description": "You are trying to open a link that will take you to <span/>.<br/> This link will be opened from your default browser.",
-		"doNotVerifyLink": "Do not verify when trying to open a link.",
-		"openLink": "Open link"
-	},
-
-	"songUnplayableErrorPrompt": {
-		"title": "Couldn't play the song",
-		"description": "Seems like we can't play that song. Please check whether the selected song is available in your system and accessible by the app.",
-		"formatNotSupportedTitle": "Is this song supported in Nora?",
-		"formatNotSupportedDescription": "This audio file format may not be supported by your current system or browser configuration. Please check the list of supported formats below.",
-		"flacNotSupportedDescription": "FLAC files are not supported in Nora due to codec limitations in the browser engine. However, you can convert your FLAC files to MP3, OGG, or WAV format and they will play perfectly in Nora.",
-		"supportedFormatsLabel": "Supported Audio Formats:",
-		"flacConversionHint": "💡 Try converting your FLAC files to MP3 (recommended), OGG, or WAV using free tools like FFmpeg or Audacity."
-	},
-
-	"unsupportedFileMessagePrompt": {
-		"title": "Unsupported audio file",
-		"description": "You are trying to open a file with a <span/> extension, which is not supported by this app.<br/> Currently, we only support following audio formats. <div/>"
-	},
-
-	"duplicateArtistsSuggestion": {
-		"message": "<div><p>Are <span/> the same artist?</p><p>If they are, you can link content of them into a single artist, or you can ignore this suggestion.</p></div>",
-		"linkToArtist": "Link to {{name}}"
-	},
-
-	"separateArtistsSuggestion": {
-		"message": "<div><p>Are <span/> {{count}} separate artists?</p><p>If they are, you can organize them by selecting them as separate artists, or you can ignore this suggestion.</p></div>",
-		"separateAsArtists": "Separate as {{count}} artists"
-	},
-
-	"featArtistsSuggestion": {
-		"message_one": "<p>Is <span/> an artist featuring in this song?</p><p>If so, you can add that artist as an artist of the song, or you can ignore this suggestion.</p>",
-		"message_other": "<p>Are <span/> {{count}} artists featuring in this song?</p><p>If so, you can add those artists as artists of the song, or you can ignore this suggestion.</p>",
-		"featArtistsTitleReset": "Remove featuring artists information from song title after adding artists to the song.",
-		"addArtistsToSong": "Add $t(common.artistWithCount, {\"count\":{{count}}}) to the song",
-		"editInMetadataEditingPage": "Edit in the metadata editing page",
-		"modificationNotice": "Keep in mind that adding featuring artists to the song will update the song data in the library as well as the song metadata."
-	},
-
-	"biography": {
-		"readMore": "Read more...",
-		"readMoreInLastFm": "Read more in LastFM",
-		"aboutName": "About <span/>",
-		"goToTagInLastFm": "Go to {{name}} tag in LastFM"
-	},
-
-	"notifications": {
-		"clearAll": "Clear all",
-		"playingNext": "`{{title}}` will be played next.",
-		"songBlacklisted": "`{{title}}` is blacklisted.",
-		"playingNextSongsWithCount": "$t(common.songWithCount, {\"count\":{{count}}}) will be played next.",
-		"addedToQueue": "Added $t(common.songWithCount, {\"count\":{{count}}}) to the queue",
-		"suggestionIgnored": "Suggestion ignored.",
-		"songRestoreSuccess": "Song restored successfully.",
-		"songDataUpdateFailed": "Song data update failed.",
-		"noSongDataEdits": "You didn't change any song data.",
-		"selectASongToPlay": "Select a song to play",
-		"alreadyInPage": "You are already in the current page.",
-		"playbackRateChanged": "Playback rate changed to {{val}} x",
-		"playbackRateReset": "Playback rate has been reset to 1x",
-		"playbackPausedDueToSongDeletion": "Current song playback paused because the song was deleted.",
-		"languageChanged": "Changed app language successfully."
-	},
-
-	"backend": {
-		"RESYNC_SUCCESSFUL": "Library resync successfull.",
-		"RESET_SUCCESSFUL": "App reset successfully, now restarting.",
-		"RESET_FAILED": "Resetting the app failed. Reloading the app now.",
-		"APP_THEME_CHANGE": "System theme changed to {{theme}}",
-		"SONG_REMOVE_PROCESS_UPDATE": "Removed {{value}} out of {{total}} songs.",
-		"OPEN_SONG_IN_EXPLORER_FAILED": "Opening song file in explorer failed because song couldn't be found in the library.",
-		"PENDING_METADATA_UPDATES_SAVED": "Successfully saved pending metadata updates of `{{title}}`.",
-		"METADATA_UPDATE_FAILED": "Metadata update failed. {{message}}",
-		"SONG_EXT_NOT_SUPPORTED_FOR_LYRICS_SAVES": "Lyrics cannot be saved because current song extension ({{ext}}) is not supported for modifying metadata.",
-		"LASTFM_LOGIN_SUCCESS": "You successfully logged in to LastFM.",
-		"AUDIO_PARSING_PROCESS_UPDATE": "{{value}} completed out of {{total}} songs.",
-		"SONG_PALETTE_GENERATING_PROCESS_UPDATE": "Generating palettes for {{value}} out of {{total}} songs.",
-		"GENRE_PALETTE_GENERATING_PROCESS_UPDATE": "Generating palettes for {{value}} out of {{total}} genres.",
-		"LYRICS_FIND_FAILED": "We couldn't find lyrics for `{{title}}`",
-		"LYRICS_TRANSLATION_SUCCESS": "Lyrics translated successfully",
-		"LYRICS_CONVERT_SUCCESS": "Lyrics converted successfully",
-		"RESET_CONVERTED_LYRICS_SUCCESS": "Reset lyrics successfully",
-		"LYRICS_TRANSLATION_FAILED": "Failed to translate lyrics",
-		"LYRICS_TRANSLATION_TO_SAME_SOURCE_LANGUAGE": "Lyrics were requested to be translated to the same source language '{{language}}'",
-		"LYRICS_CONVERT_FAILED": "Failed to convert lyrics",
-		"RESET_CONVERTED_LYRICS_FAILED": "Failed to reset lyrics",
-		"MUSIC_FOLDER_DELETED": "`{{name}}` folder got deleted from the system. $t(common.songWithCount, {\"count\":{{count}}}) related to that folder will be removed from the library.",
-		"EMPTY_MUSIC_FOLDER_DELETED": "`{{name}}` folder got deleted from the system. No songs found related to the folder. Library will be unaffected.",
-		"WHITELISTING_FOLDER_FAILED_DUE_TO_BLACKLISTED_PARENT_FOLDER": "Couldn't whitelist `{{folderName}}` folder because its parent folder '{{parentFolderName}}' is also blacklisted. Whitelist the parent folder to whitelist this folder.",
-		"WHITELISTING_SONG_FAILED_DUE_TO_BLACKLISTED_DIRECTORY": "'{{songName}}' cannot be whitelisted because its directory '{{directoryName}}' is also blacklisted. Whitelist the directory to whitelist this song.",
-		"SONG_WHITELISTED": "$t(common.songWithCount, {\"count\":{{count}}}) restored from the blacklist.",
-		"ARTWORK_SAVED": "Saved the artwork to the request location.",
-		"DESTINATION_NOT_SELECTED": "No save destination selected.",
-		"ARTWORK_SAVE_FAILED": "Failed to save the artwork.",
-		"PLAYBACK_FROM_UNKNOWN_SOURCE": "You are playing a song outside from your library.",
-		"ARTIST_DISLIKE": "`{{name}}` has been removed from favorites.",
-		"ARTIST_LIKE": "`{{name}}` has been added to favorites.",
-		"SONG_DISLIKE": "`{{name}}` has been removed from favorites.",
-		"SONG_LIKE": "`{{name}}` has been added to favorites.",
-		"SONG_DELETED": "`{{name}}` song deleted from the system.",
-		"FOLDER_PARSED_FOR_DIRECTORIES": "$t(folder.directoryCount, {\"count\":{{count}}}) found in $t(folder.selectedFolderCount, {\"count\":{{folderCount}}}).",
-		"NO_MORE_SONG_PALETTES": "No more palettes for songs to be generated.",
-		"NO_MORE_GENRE_PALETTES": "No more palettes for genres to be generated.",
-		"PARSE_FAILED": "`{{name}}` failed when trying to add the song to the library. Go to settings to resync the library.",
-		"PARSE_SUCCESSFUL": "`{{name}}` song added to the library.",
-		"LYRICS_SAVE_QUEUED": "Lyrics for `{{title}}` will be saved automatically.",
-		"LYRICS_SAVED_IN_LRC_FILE": "`Lyrics for this song with '{{ext}}' extension will be saved in an LRC file.",
-		"PENDING_LYRICS_SAVED": "Successfully saved pending lyrics of `{{title}}`.",
-		"ADDED_SONGS_TO_PLAYLIST": "Added $t(common.songWithCount, {\"count\":{{count}}}) to `{{name}}` successfully.",
-		"APPDATA_IMPORT_STARTED": "Started to import app data. Please wait...",
-		"APPDATA_IMPORT_SUCCESS": "Imported app data successfully.",
-		"APPDATA_IMPORT_SUCCESS_WITH_PENDING_RESTART": "$t(backend.APPDATA_IMPORT_SUCCESS) Restarting app in 5 seconds.",
-		"APPDATA_IMPORT_FAILED": "Failed to import app data.",
-		"APPDATA_IMPORT_FAILED_DUE_TO_MISSING_FILES": "$t(backend.APPDATA_IMPORT_FAILED) Missing required files in the selected folder.",
-		"APPDATA_EXPORT_STARTED": "Started to export app data. Please wait...",
-		"APPDATA_EXPORT_SUCCESS": "Exported app data successfully.",
-		"APPDATA_EXPORT_FAILED": "Error occurred when exporting app data.",
-		"PLAYLIST_EXPORT_SUCCESS": "Exported `{{name}}` playlist successfully.",
-		"PLAYLIST_EXPORT_FAILED": "Error occurred when exporting `{{name}}` playlist.",
-		"PLAYLIST_IMPORT_SUCCESS": "Imported `{{name}}` playlist successfully.",
-		"PLAYLIST_IMPORT_FAILED": "Failed to import the playlist.",
-		"PLAYLIST_IMPORT_FAILED_DUE_TO_SONGS_OUTSIDE_LIBRARY": "Found $t(common.songWithCount, {\"count\":{{count}}}) outside the library when importing a playlist which is not supported.",
-		"PLAYLIST_IMPORT_FAILED_DUE_TO_INVALID_FILE_DATA": "Failed to import the playlist because user selected a file with invalid file data.",
-		"PLAYLIST_IMPORT_FAILED_DUE_TO_INVALID_FILE_EXTENSION": "Playlist import failed because the selected file type wasn't '.m3u8'.",
-		"PLAYLIST_IMPORT_TO_EXISTING_PLAYLIST": "Imported $t(common.songWithCount, {\"count\":{{count}}}) to the existing `{{name}}` playlist.",
-		"PLAYLIST_IMPORT_TO_EXISTING_PLAYLIST_FAILED": "Error occurred when importing songs to an existing playlist.",
-		"PLAYLIST_CREATION_FAILED": "Failed to create a playlist.",
-		"PLAYLIST_RENAME_SUCCESS": "Playlist renamed successfully.",
-		"PLAYLIST_NOT_FOUND": "Playlist not found.",
-		"SONG_REPARSE_SUCCESS": "Successfully reparsed `{{title}}`.",
-		"SONG_REPARSE_FAILED": "Error occurred when re-parsing the song."
-	},
-
-	"discordrpc": {
-		"noraOnGitHub": "Nora on GitHub",
-		"untitledSong": "An untitled song",
-		"unknownArtist": "an unknown artist",
-		"playingASong": "Playing a song"
-	}
+  "common": {
+    "song_one": "song",
+    "song_other": "Songs",
+    "playlist_one": "playlist",
+    "playlist_other": "Playlists",
+    "artist_one": "artist",
+    "artist_other": "Artists",
+    "album_one": "album",
+    "album_other": "Albums",
+    "genre_one": "genre",
+    "genre_other": "Genres",
+    "folder_one": "folder",
+    "folder_other": "Folders",
+    "songWithCount_one": "{{count}} song",
+    "songWithCount_other": "{{count}} songs",
+    "playlistWithCount_one": "{{count}} playlist",
+    "playlistWithCount_other": "{{count}} playlists",
+    "artistWithCount_one": "{{count}} artist",
+    "artistWithCount_other": "{{count}} artists",
+    "albumWithCount_one": "{{count}} album",
+    "albumWithCount_other": "{{count}} albums",
+    "genreWithCount_one": "{{count}} genre",
+    "genreWithCount_other": "{{count}} genres",
+    "folderWithCount_one": "{{count}} folder",
+    "folderWithCount_other": "{{count}} folders",
+    "subFolderWithCount_one": "{{count}} sub-folder",
+    "subFolderWithCount_other": "{{count}} sub-folders",
+
+    "selectionWithCount_one": "{{count}} selected",
+    "selectionWithCount_other": "{{count}} selected",
+
+    "shownWithCount": "{{count}} shown",
+
+    "unknownTitle": "Unknown title",
+    "unknownArtist": "Unknown artist",
+    "unknownAlbum": "Unknown album",
+    "unknownGenre": "Unknown genre",
+    "unknownFolder": "Unknown folder",
+    "unknownLyricsProvider": "Unknown lyrics provider",
+
+    "songTitle": "Song title",
+    "duration": "Duration",
+    "albumArtists": "Song album artists",
+    "albumTrackNo": "Album track number",
+    "releasedYear": "Release year",
+    "songAddedOn": "Song added on",
+    "lastModifiedOn": "Last modified on",
+    "sampleRate": "Sample rate",
+    "bitRate": "Bitrate",
+    "noOfAudioChannels": "Number of audio channels",
+    "channelWithCount_one": "{{count}} channel (Mono)",
+    "channelWithCount_other": "{{count}} channels (Stereo)",
+    "songLocation": "Song location",
+    "lyrics": "Song lyrics",
+    "syncedLyrics": "Synced lyrics",
+    "unsyncedLyrics": "Unsynced lyrics",
+
+    "play": "Play",
+    "playNext": "Play next",
+    "playNextAll": "Add all to play next",
+    "shuffleAndPlay": "Shuffle and play",
+    "shuffleAndPlayAll": "Shuffle and play all",
+    "playAll": "Play all",
+    "addToQueue": "Add to queue",
+    "removeFromQueue": "Remove from queue",
+    "addSongsToQueue": "Add Songs to queue",
+    "createAQueue": "Create a queue",
+    "info": "Info",
+    "select": "Select",
+    "unselect": "Unselect",
+    "selectAll": "Select all",
+    "unselectAll": "Unselect all",
+    "showAll": "Show all",
+    "cancel": "Cancel",
+    "search": "Search",
+    "help": "Help",
+    "copy": "Copy",
+
+    "sortBy": "Sort By",
+    "filterBy": "Filter By",
+    "moreOptions": "More options",
+    "title": "Title",
+    "suggestion": "Suggestion",
+    "hideSuggestion": "Hide suggestion",
+    "showSuggestion": "Show suggestion",
+    "and": "and",
+    "ignore": "Ignore",
+    "goBack": "Go back",
+    "saveArtwork": "Save artwork",
+    "readMoreAboutTitle": "Read more about the `{{title}}`",
+    "doNotShowThisMessageAgain": "Do not show again.",
+    "artistConflictResolved": "Artist conflict resolved successfully.",
+    "featArtistSuggestionResolved": "Featuring artists suggestion resolved successfully.",
+    "hasInternet": "You are connected to internet.",
+    "noInternet": "You are not connected to internet.",
+    "newUpdateAvailable": "New app update available.",
+    "checkingForUpdates": "Checking for app updates...",
+    "updateCheckError": "Error occurred when checking for app updates.",
+    "updateCheckErrorNoInternet": "$t(common.updateCheckError) $t(common.noInternet)",
+    "optionDisabled": "This option is disabled.",
+    "somethingWentWrong": "Something went wrong.",
+    "details": "Details",
+    "restartApp": "Restart app",
+    "ok": "Okay",
+    "loading": "Loading"
+  },
+
+  "titleBar": {
+    "changeTheme": "Change theme",
+    "goBack": "Go Back (Alt + Left-Arrow)",
+    "goHome": "Go to Home (Alt + Home)",
+    "goForward": "Go Forward (Alt + Right-Arrow)",
+
+    "minimize": "Minimize",
+    "maximize": "Maximize",
+    "close": "Close"
+  },
+
+  "player": {
+    "goToMainPlayer": "Go to Main Player (Ctrl + N)",
+    "openInMiniPlayer": "Open in Mini player (Ctrl + N)",
+    "openInFullScreen": "Open in Fullscreen",
+    "likeDislike": "Like/Dislike (Ctrl + H)",
+    "likeDislikeDisabled": "Like/dislike songs is disabled because the song currently playing is from an unknown source and doesn't support likes.",
+    "prevSong": "Previous song (Ctrl + Left Arrow)",
+    "playPause": "Play/Pause (Space)",
+    "nextSong": "Next song (Ctrl + Right Arrow)",
+    "lyrics": "Lyrics (Ctrl + L)",
+    "shuffle": "Shuffle (Ctrl + S)",
+    "repeat": "Repeat (Ctrl + T)",
+    "muteUnmute": "Mute/Unmute (Ctrl + M)",
+    "currentQueue": "Current queue (Ctrl + Q)",
+    "adjustPlaybackSpeed": "Adjust playback speed",
+    "showCurrentQueue": "Show current queue",
+    "showMiniPlayer": "Show Mini Player",
+    "otherSettings": "Other settings",
+    "upNext": "UP NEXT: ",
+    "closeUpNext": "Close 'UP NEXT'",
+    "by": "by",
+
+    "errorTitle": "An error ocurred in the player.",
+    "errorMessage": "$t(player.errorTitle)<br /> This could be a result of trying to play a corrupted song. <details/>",
+    "noErrorMessage": "No error message generated"
+  },
+
+  "sortTypes": {
+    "aToZ": "A to Z",
+    "zToA": "Z to A",
+    "dateAddedAscending": "Oldest",
+    "dateAddedDescending": "Newest",
+    "releasedYearAscending": "Released year (Ascending)",
+    "releasedYearDescending": "Released year (Descending)",
+    "allTimeMostListened": "Most-listened (All time)",
+    "allTimeLeastListened": "Least-listened (All time)",
+    "monthlyMostListened": "Most-listened (This month)",
+    "monthlyLeastListened": "Least-listened (This month)",
+    "artistNameAscending": "Artist name (A to Z)",
+    "artistNameDescending": "Artist name (Z to A)",
+    "albumNameAscending": "Album name (A to Z)",
+    "albumNameDescending": "Album name (Z to A)",
+    "noOfSongsDescending": "Highest amount of songs",
+    "noOfSongsAscending": "Lowest amount of songs",
+    "blacklistedFolders": "Blacklisted folders",
+    "whitelistedFolders": "Whitelisted folders",
+    "mostLovedDescending": "Most-loved",
+    "mostLovedAscending": "Least-loved",
+    "trackNoAscending": "Track number (Ascending)",
+    "trackNoDescending": "Track number (Descending)",
+    "addedOrder": "Added order"
+  },
+
+  "filterTypes": {
+    "notSelected": "Not Selected",
+    "blacklistedSongs": "Blacklisted songs",
+    "whitelistedSongs": "Whitelisted songs",
+    "favorites": "Favorites",
+    "nonFavorites": "Non-favorites"
+  },
+
+  "equalizerPresets": {
+    "custom": "Custom",
+    "flat": "Flat",
+    "acoustic": "Acoustic",
+    "bassBooster": "Bass booster",
+    "bassReducer": "Bass reducer",
+    "classical": "Classical",
+    "club": "Club",
+    "dance": "Dance",
+    "deep": "Deep",
+    "electronic": "Electronic",
+    "hipHop": "Hip Hop",
+    "jazz": "Jazz",
+    "latin": "Latin",
+    "live": "Live",
+    "loudness": "Loudness",
+    "lounge": "Lounge",
+    "metal": "Metal",
+    "piano": "Piano",
+    "pop": "Pop",
+    "reggae": "Reggae",
+    "rnb": "RnB",
+    "rock": "Rock",
+    "ska": "Ska",
+    "smallSpeakers": "Small speakers",
+    "soft": "Soft",
+    "softRock": "Soft rock",
+    "spokenWord": "Spoken word",
+    "techno": "Techno",
+    "trebleBooster": "Treble booster",
+    "trebleReducer": "Treble reducer",
+    "vocalBooster": "Vocal booster"
+  },
+
+  "song": {
+    "showInFileExplorer": "Show in File Explorer",
+    "artwork": "Song artwork",
+    "selectedSongCount": "{{count}} selected $t(common.song, {\"count\":{{count}}})",
+    "likeSong": "Add to favorites",
+    "unlikeSong": "Remove from favorites",
+    "toggleLikeSongs": "Add/remove songs from favorites",
+    "addToPlaylists": "Add to playlist(s)",
+    "goToAlbum": "Go to album",
+    "editSongTags": "Edit song tags",
+    "reparseSong": "Re-parse song",
+    "blacklistSong_one": "Blacklist song",
+    "blacklistSong_other": "Blacklist songs",
+    "deblacklist": "Restore from blacklist",
+    "delete": "Delete from system",
+    "playingNext": "Playing next",
+    "playingNow": "Playing now",
+    "blacklisted": "Blacklisted",
+    "likedThisSong": "You liked this song",
+    "dislikedThisSong": "You didn't like this song"
+  },
+
+  "artist": {
+    "playAllSongs": "Play all songs",
+    "toggleLikeArtists": "Add/remove artists from favorites",
+    "likeArtist": "Add artist to favorites",
+    "dislikeArtist": "Remove artist from favorites",
+    "selectedArtistCount": "{{count}} selected $t(common.artist, {\"count\":{{count}}})"
+  },
+
+  "folder": {
+    "toggleBlacklistFolder": "Toggle blacklist folder",
+    "blacklistFolder": "Blacklist folder",
+    "selectedFolderCount": "{{count}} selected $t(common.folder, {\"count\":{{count}}})",
+    "selectedParentFolderCount_one": "{{count}} selected parent folder",
+    "selectedParentFolderCount_other": "{{count}} selected parent folders",
+    "directoryCount_one": "{{count}} directory",
+    "directoryCount_other": "{{count}} directories",
+    "selectedDirectoryCount_one": "{{count}} selected directory",
+    "selectedDirectoryCount_other": "{{count}} selected directories"
+  },
+
+  "playlist": {
+    "changeArtwork": "Change artwork",
+    "addArtwork": "Add artwork",
+    "playlistArtworkUpdateSuccess": "Updated playlist artwork successfully.",
+    "renamePlaylist": "Rename playlist",
+    "exportPlaylist": "Export playlist",
+    "importSongs": "Import songs from M3U8",
+    "deleteSelectedPlaylists": "Delete selected playlist(s)",
+    "deletePlaylist_one": "Delete playlist",
+    "deletePlaylist_other": "Delete playlists",
+    "selectedPlaylistCount": "{{count}} selected $t(common.playlist, {\"count\":{{count}}})",
+    "empty": "Seems like this playlist is empty."
+  },
+
+  "album": {
+    "selectedAlbumCount": "{{count}} selected $t(common.album, {\"count\":{{count}}})"
+  },
+
+  "genre": {
+    "selectedGenreCount": "{{count}} selected $t(common.genre, {\"count\":{{count}}})"
+  },
+
+  "homePage": {
+    "empty": "There's nothing here..",
+    "emptyDescription": "It seems like you haven't added any music folders to your library yet.",
+    "loading": "Hold on. We are getting everything ready for you...",
+    "listenMoreToShowMetrics": "Listen to more songs to show additional metrics.",
+
+    "recentlyAddedSongs": "Recently added songs",
+    "recentlyPlayedSongs": "Recently played songs",
+    "recentArtists": "Recent artists",
+    "mostLovedSongs": "Most-loved songs",
+    "mostLovedArtists": "Most-loved artists",
+
+    "openSongsWithNewestSortOption": "Opens 'Songs' with 'Newest' sort option.",
+    "openPlaybackHistory": "Opens 'History' playlist with 'addedOrder' sort option",
+    "openFavoritesWithAllTimeMostListenedSortOption": "Opens 'Favorites' playlist with 'AllTimeMostListened' sort option",
+
+    "noSongsAvailable": "No songs available",
+    "stayCalm": "Stay calm",
+    "favoritesAndRecaps": "Favorites and Recaps"
+  },
+
+  "searchPage": {
+    "addFolder": "Add folder",
+    "enablePredictiveSearch": "Enable predictive search",
+    "disablePredictiveSearch": "Disable predictive search",
+    "searchForAnything": "Search for anything",
+    "searchForAnythingInLibrary": "Search for anything in your library",
+    "separateKeywords": "Use ' ; ' to separate keywords while searching.",
+    "allFilter": "All",
+    "mostRelevant": "Most relevant",
+    "resultCount_one": "{{count}} result",
+    "resultCount_other": "{{count}} results",
+    "resultAndVisibleCount_other": "{{count}} results ($t(common.shownWithCount, {\"count\":{{noVisible}}}))",
+    "noResults": "There's nothing that matches with what you're looking for.",
+    "recentSearchResultTooltipLabel": "Search for '{{value}}'",
+    "showingResultsFor": "Showing results for <span>'{{query}}'</span>",
+    "showingResultsForWithFilter": "Showing results for <span>'{{query}}'</span> on <span>{{filter}}</span>",
+
+    "a": "Search for anything"
+  },
+
+  "songsPage": {
+    "loading": "Hold on. We are getting everything ready for you...",
+    "empty": "There's nothing here.."
+  },
+
+  "artistsPage": {
+    "empty": "There's nothing here..."
+  },
+
+  "foldersPage": {
+    "addFolder": "Add folder",
+    "musicFolders": "Music folders",
+    "empty": "No folders added to your library."
+  },
+
+  "playlistsPage": {
+    "createNewPlaylist": "Create new playlist",
+    "importPlaylist": "Import a playlist",
+    "addPlaylist": "Add a playlist",
+    "removeFromThisPlaylist": "Remove from this playlist",
+    "removeSongFromPlaylistSuccess": "`{{title}}` removed from '{{playlistName}}'this playlist",
+    "createdOn": "Created on {{val, datetime}}",
+    "clearSongHistoryConfirm": "Clear song history",
+    "clearSongHistoryConfirmNotice": "Are you sure you want to clear your song history? This action cannot be undone.",
+    "clearSongHistorySuccess": "Your song history has been cleared successfully.",
+    "empty": "No playlists created yet.",
+
+    "favorites": "Favorites",
+    "history": "History"
+  },
+
+  "albumsPage": {
+    "empty": "There's nothing here..."
+  },
+
+  "genresPage": {
+    "empty": "There's nothing here..."
+  },
+
+  "settingsPage": {
+    "settings": "Settings",
+
+    "appearance": "Appearance",
+    "changeTheme": "Change the theme of the application to your preference.",
+    "lightTheme": "Light theme",
+    "darkTheme": "Dark theme",
+    "systemTheme": "System theme",
+
+    "enableImageBasedDynamicThemes": "Enable Dynamic Themes",
+    "enableImageBasedDynamicThemesDescription": "Change app theme dynamically based on the theme of the current playing song cover image",
+
+    "language": "Language",
+    "languageDescription": "Select the language you want Nora to be displayed in.",
+
+    "audioPlayback": "Audio playback",
+    "showRemainingSongDuration": "Show remaining song duration",
+    "showRemainingSongDurationDescription": "Shows the remaining duration of the song instead of the default song duration.",
+    "playbackRate": "Playback speed",
+    "changePlaybackRate": "Change the default playback speed of the player.",
+    "resetPlaybackRate": "Reset to 1x",
+    "seekbarScrollInterval": "Change the increment amount when scrolled over audio seek bar and volume seek bar.",
+    "second": "second",
+    "second_other": "seconds",
+
+    "accounts": "Accounts",
+    "integrateLastFm": "Integrate Last.fm with Nora.",
+    "lastFmLogo": "LastFM logo",
+    "lastFmConnected": "LastFM connected",
+    "lastFmNotConnected": "LastFM not connected",
+    "loggedInAs": "Logged in as",
+    "lastFmDescription1": "Connect with Last.fm to enable Scrobbling.",
+    "lastFmDescription2": "Scrobbling is a way to send information about the music a user is listening to.",
+    "lastFmDescription3": "Whenever you listen to a song, Last.fm “Scrobbles” that song and adds it to your account.",
+    "lastFmDescription4": "This feature requires an internet connection.",
+    "authenticateAgain": "Authenticate again",
+    "loginInBrowser": "Login via browser",
+    "scrobblingDescription": "Enable Last.fm Scrobbling to send data related to how you listen to songs.",
+    "enableScrobbling": "Enable Last.fm Scrobbling",
+    "sendFavoritesToLastFmDescription": "Send favorites data to Last.fm when you like/dislike songs.",
+    "sendFavoritesToLastFm": "Send favorites data",
+    "sendNowPlayingToLastFmDescription": "Send the currently playing song data to Last.fm automatically when you start to play a song.",
+    "sendNowPlayingToLastFm": "Send currently playing song data",
+    "enableDiscordRpcDescription": "Integrate Discord Rich Presence with Nora",
+    "enableDiscordRpc": "Enable Discord Rich Presence",
+
+    "doNotSaveLyricsAutomatically": "Don't save lyrics automatically",
+    "syncedLyricsOnly": "Synced lyrics only",
+    "saveEitherLyrics": "Synced or unsynced lyrics",
+    "lyrics": "Lyrics",
+    "enableMusixmatchLyricsDescription": "Enable Musixmatch Lyrics, which provides synced and unsynced lyrics for your songs on-demand.",
+    "musixmatchDisclaimerNotice": "Enabling and using this feature means that you agree to, and accept the <Button>Musixmatch Lyrics Disclaimer</Button>.",
+    "editMusixmatchSettings": "Edit Musixmatch settings",
+    "enableMusixmatch": "Enable Musixmatch Lyrics",
+    "musixmatchEnabled": "Musixmatch Lyrics is enabled",
+    "saveLyricsAutomaticallyDescription": "Select an option to save song lyrics automatically when fetched in lyrics page.",
+    "saveLyricsAutomaticallyInfo": "Automatically downloaded lyrics will be saved after the current song is finished to prevent any corruption from happening.",
+    "saveLyricsInLrcFilesDescription": "Enable saving lyrics in LRC files for songs that support metadata editing. Nora will save lyrics in an LRC file if the song file doesn't support metadata editing.",
+    "saveLyricsInLrcFiles": "Also save lyrics in LRC files for supported songs",
+    "autoTranslateLyricsDescription": "Enable automatic translation of lyrics to your selected language. Lyrics will be automatically translated even if the lyrics have the same language as your selected language.",
+    "autoTranslateLyrics": "Auto translate lyrics",
+    "autoConvertLyricsDescription": "Enable automatic conversion of supported lyrics to Latin characters. Currently, Nora supports converting Japanese, Chinese, and Korean lyrics to their respective Romanization systems.",
+    "autoConvertLyrics": "Auto convert lyrics",
+    "lrcFileCustomSaveLocationDescription": "Select a custom location to save LRC files of songs if you don't want to save them in the same folder as the relative song.",
+    "selectedCustomLocation": "Selected custom location",
+    "setCustomLocation": "Set custom location",
+
+    "equalizer": "Equalizer",
+    "reset": "Reset",
+
+    "defaultPage": "Default page",
+    "changeDefaultPageDescription": "Change the default page you want to see when you open the app.",
+
+    "preferences": "Preferences",
+    "songIndexingDescription": "Enables indexing of songs in pages, adding a number to each song in the Songs tab.",
+    "enableSongIndexing": "Enable song indexing",
+    "showTrackNumberAsSongIndexDescription": "Show track number in front of the song when in albums page.",
+    "showTrackNumberAsSongIndex": "Show track number as song index",
+    "showArtistArtworkNearSongControlsDescription": "Shows artist artworks next to the artist names near the title of the song on the song controls panel.",
+    "showArtistArtworkNearSongControls": "Show available artist artworks next to their name (bottom left).",
+    "disableBackgroundArtworksDescription": "Disables the large artworks shown on the background of some pages.",
+    "disableBackgroundArtworks": "Disable background artworks",
+    "playlistArtworksDescription": "Change the behavior of artworks made from song covers.",
+    "enablePlaylistArtworks": "Enable artworks made from song covers on playlists",
+    "shuffleArtworkFromSongCovers": "Enable shuffling the artwork made from song covers. (The artworks shuffle each time a page refresh happens.)",
+
+    "accessibility": "Accessibility",
+    "reducedMotionDescription": "Removes animation that appears in the app. This will also reduce the smoothness of the app.",
+    "enableReducedMotion": "Enable reduced motion",
+
+    "performance": "Performance",
+    "removeAnimationOnBatteryDescription": "Removes the animations in the app when your system is on battery power.",
+    "removeAnimationOnBattery": "Remove animations when on battery power.",
+    "allowToPreventScreenSleepingDescription": "Allow Nora to prevent the display from going to sleep in situations with no user activity like displaying lyrics.",
+    "allowToPreventScreenSleeping": "Allow preventing the display from going to sleep.",
+
+    "startupAndWindowCustomization": "Startup and Windows settings",
+    "autoLaunchAtStartDescription": "Enabling this setting will automatically launch Nora when you login to your computer.",
+    "autoLaunchAtStart": "Auto launch at startup",
+    "hideWindowAtStartDescription": "Configure whether Nora should be visible when it's started up.",
+    "hideWindowAtStart": "Launch Nora in the System Tray on startup",
+    "hideWindowOnCloseDescription": "Configure how Nora should behave when you click the close button.",
+    "hideWindowOnClose": "Hide Nora to the System Tray when the close button is clicked.",
+    "trayClickBehaviorDescription": "Configure how the system tray icon behaves when clicked.",
+    "traySingleClickTogglesWindow": "Single-click tray icon toggles player window.",
+
+    "storage": "Storage",
+    "storageDescription": "See how Nora manages your library and utilizes your storage.",
+
+    "fullStorageSpace": "Full storage usage",
+    "fullStorageOutOfUsage": "{{value}} out of {{total}}",
+    "freeSpace": "Free space",
+    "otherApplications": "Other applications",
+    "artworkCache": "Artwork cache",
+    "tempArtworkCache": "Temp artwork cache",
+    "databaseData": "Database",
+    "songsData": "Song data",
+    "artistsData": "Artist data",
+    "albumsData": "Album data",
+    "playlistsData": "Playlist data",
+    "palettesData": "Palette data",
+    "genresData": "Genre data",
+    "appLogs": "Application logs",
+    "userData": "User data",
+    "internalAppFiles": "Internal application files",
+    "storageUseForLibraryData": "Storage usage for library data",
+    "otherAppFiles": "Other application files",
+    "generated": "Generated",
+    "generateStorageMetrics": "Generate storage metrics",
+    "generateStorageMetricsAgain": "Generate storage metrics again",
+    "noStorageMetrics": "Seems like you haven't generated storage metrics yet.",
+    "storageMetricsGenerationDisclaimer": "Generating storage metrics is a relatively demanding computational task, this means Nora may become unresponsive temporarily. Please be patient...",
+    "storageMetricsGenerationError": "Seems like something went wrong on our end. Please report this to the developer.",
+
+    "advanced": "Advanced",
+    "saveVerboseLogsDescription": "Save verbose logs for debugging purposes. This will increase the size of the logs.",
+    "saveVerboseLogs": "Save verbose logs",
+
+    "about": "About",
+    "releasedOn": "Released on {{val, datetime}}",
+    "noraWebsite": "Nora's official website",
+    "noraDiscordServer": "Nora's official Discord server",
+    "noraGithubRepo": "Nora's Github repository",
+    "noraGithubIssues": "Nora's Github issues",
+    "noraLocalizationStatus": "Nora localization status",
+    "noraDescription": "Nora is an elegant music player built using Electron and React.",
+    "noraInspiration": "Inspired by <Hyperlink>Oto Music for Android</Hyperlink> by Piyush Mamidwar.",
+    "otoMusicOnPlayStore": "Oto Music for Android on the Play Store",
+    "noraLicenseNotice": "This product is licensed under the <Button>MIT licence.</Button>",
+    "appLicense": "App license",
+    "releaseNotes": "Release notes",
+    "openSourceLicenses": "Open-source licenses",
+    "openLogFile": "Open log file",
+    "openDevtools": "Open dev-tools",
+    "resyncLibrary": "Resync library",
+    "generatePalettes": "Generate palettes",
+    "appShortcuts": "App shortcuts",
+
+    "resetApp": "Reset app",
+    "clearOptionalData": "Clear optional data",
+    "clearHistory": "Clear history",
+    "confirmSongHistoryDeletion": "Clear song history",
+    "songHistoryDeletionDisclaimer": "Are you sure you want to clear your song history? This action cannot be undone.",
+    "songHistoryDeletionSuccess": "Your song history has been cleared successfully.",
+    "exportAppData": "Export app data",
+    "importAppData": "Import app data",
+    "createIssueOnNoraGithubRepo": "create an issue on $t(settingsPage.noraGithubRepo)",
+    "contact": "If you have any feedback about bugs, feature requests (etc.) about the app, please <Hyperlink>$t(settingsPage.createIssueOnNoraGithubRepo)</Hyperlink>",
+    "emailContact": "or contact me through my email.",
+    "loveNora": "Made with <span>❤</span> by <Hyperlink>Sandakan Nipunajith</Hyperlink>.",
+    "sandakanGithubProfile": "Sandakan's Github profile",
+    "beautifulSriLanka": "Beautiful Sri Lanka"
+  },
+
+  "artistInfoPage": {
+    "likeArtist": "Like {{name}}",
+    "dislikeArtist": "Dislike {{name}}",
+    "appearsInAlbums": "Appears in albums",
+    "appearsInSongs": "Appears in songs",
+    "similarArtistsInLibrary": "Similar artists in the library",
+    "otherSimilarArtists": "Other similar artists",
+    "viewInLastFm": "View `{{name}}` in Last.fm"
+  },
+
+  "albumInfoPage": {
+    "unavailableTracks": "Unavailable Tracks of this Album"
+  },
+
+  "currentQueuePage": {
+    "queue": "Currently Playing Queue",
+    "folderWithName": "{{name}} Folder",
+    "enableAutoScrolling": "Enable Auto Scrolling",
+    "disableAutoScrolling": "Disable Auto Scrolling",
+    "scrollToCurrentPlayingSong": "Scroll to currently playing song",
+    "shuffleQueue": "Shuffle Queue",
+    "queueShuffleSuccess": "Queue shuffled successfully.",
+    "clearQueue": "Clear Queue",
+    "queueCleared": "Queue cleared.",
+    "durationRemaining": "{{duration}} remaining",
+    "empty": "Queue is empty."
+  },
+
+  "lyricsEditingPage": {
+    "lyricsText": "Lyrics Text",
+    "startInSeconds": "Start in seconds",
+    "endInSeconds": "End in seconds",
+    "fromTo": "From {{start}} to {{end}}",
+    "deleteLine": "Delete Line",
+    "addLineAbove": "Add Line Above",
+    "addLineBelow": "Add Line Below",
+    "addInstrumentalLineBelow": "Add Instrumental Line Below",
+    "editLine": "Edit Line",
+    "finishEditing": "Finish Editing",
+    "resetLyrics": "Reset Lyrics",
+    "resetLyricsConfirm": "Are your sure that you want to Reset Lyrics?",
+    "resetLyricsConfirmMessage": "<p>You will lose <span>recent lyrics line modifications</span> and <span>start/end synchronization data</span> if you continue this action.</p> <br/> <p>This action is irreversible.</p>",
+    "incorrectSongTitle": "Not in the right song",
+    "incorrectSongMessage": "To start editing, play `{{title}}` song.",
+    "lyricsEditor": "Lyrics Editor",
+    "playbackSpeed": "Speed",
+    "playbackTime": "Time",
+    "offsetWithCount": "{{count}} offset",
+    "saveLyrics": "Save Lyrics",
+    "stopAndEditLyrics": "Stop and Edit Lyrics",
+    "playLyrics": "Play Lyrics",
+    "configure": "Configure"
+  },
+
+  "lyricsPage": {
+    "noLyrics": "Lyrics not found.",
+    "noLyricsDescription": "We couldn't find any lyrics for this song. You can add your own in the Tag Editor.",
+    "noSyncedLyrics": "No synced lyrics found.",
+    "noSyncedLyricsDescription": "We couldn't find any synced lyrics for this song.",
+    "noOnlineLyrics": "No online lyrics found.",
+    "noOfflineLyrics": "No offline lyrics found.",
+    "noSavedLyrics": "No saved lyrics found.",
+    "onlineLyricsRefreshFailed": "Failed to refresh online lyrics.",
+    "offlineLyricsForSong": "Offline lyrics for `{{title}}`",
+    "onlineLyricsForSong": "Online lyrics for `{{title}}`",
+    "editLyrics": "Edit lyrics in the editor",
+    "translateLyrics": "Translate lyrics",
+    "romanizeLyrics": "Romanize Japanese lyrics",
+    "convertLyricsToPinyin": "Convert Chinese lyrics to Pinyin",
+    "convertLyricsToRomaja": "Convert Korean lyrics to Romaja",
+    "resetLyrics": "Reset Lyrics",
+    "showOnlineLyrics": "Show online lyrics",
+    "refreshOnlineLyrics": "Refresh online lyrics",
+    "showSavedLyrics": "Show saved lyrics",
+
+    "lyricsLoading": "Looking for lyrics",
+    "lyricsLoadingDescription": "Hang on... We're looking everywhere...",
+    "noInternet": "No internet connection",
+    "noInternetDescription": "There are no offline lyrics for this song. You need an internet connection to check for online lyrics.",
+    "lyricsProvidedBy": "Lyrics provided by <Hyperlink/>",
+    "lyricsTranslatedBy": "Lyrics translated using Google Translate"
+  },
+
+  "songInfoPage": {
+    "listensCount": "{{count}} listens",
+    "listeningActivityInLastMonths": "Listening activity in the Last {{count}} Months",
+    "similarTracksInLibrary": "Similar tracks in your library",
+    "otherSimilarTracks": "Other similar tracks",
+    "additionalSongInfo": "Additional song information",
+    "allTimeListens": "All time listens",
+    "listensThisMonth": "Listens this month",
+    "listensThisYear": "Listens this year",
+    "totalSongSkips": "Total song skips",
+    "fullSongListens": "Full song listens",
+    "mostSoughtPosition": "Most sought position",
+    "mostSoughtFrequency": "Most sought frequency",
+    "lovedSong": "You loved this song",
+    "unlovedSong": "You didn't like this song",
+    "byArtists": " <By>by</By> <span>{{val, list}}</span>"
+  },
+
+  "songTagsEditingPage": {
+    "editArtwork": "Edit artwork",
+    "removeArtwork": "Remove artwork",
+    "lyricsIncluded": "Lyrics included",
+    "addToMetadata": "Add to metadata",
+    "customizeMetadata": "Customize metadata",
+    "songMetadataEditor": "Song metadata editor",
+    "searchMetadataOnInternet": "Search metadata on the internet",
+    "saveTags": "Save Metadata Tags",
+    "updateAddedToBeSavedLater": "Metadata updates of currently playing songs will be saved after the song playback is finished.",
+    "pendingUpdateAvailable": "A metadata update of this song is pending to be saved.",
+    "saveTagsNotSupportedTitle": "Not Supported",
+    "saveTagsNotSupportedDescription": "<P1>Nora currently doesn't support editing song metadata in <Format/> format.</P1><P2>Currently only <SupportedFormat/> format is supported.",
+    "albumArtistNotMentioned": "Song is already part of the album named `{{title}}` but its artist(s) '{{artists}}' is/are not specified as the album artist(s) for this song.",
+    "songAlbumArtistMismatch": "Selected album artist(s) '{{albumArtists}}' don't match with the selected album '{{albumTitle}}' artist(s) '{{songAlbumArtists}}'.",
+    "searchForArtists": "Search for artists here",
+    "searchForAlbums": "Search for albums here",
+    "searchForGenres": "Search for genres here",
+    "addNewArtist": "Add new artist `{{name}}`",
+    "addNewAlbum": "Add new album `{{name}}`",
+    "addNewGenre": "Add new genre `{{name}}`",
+    "albumName": "Album name",
+    "songArtists": "Song artists",
+    "songName": "Song name",
+    "composer": "Composer",
+    "syncedLyricsFetchFailed": "Failed to fetch synced lyrics.",
+    "lyricsEnhancedSynced": "Lyrics are enhanced synced.",
+    "lyricsNotEnhancedSynced": "Lyrics are not enhanced synced.",
+    "enhancedLyricsSupported": "Enhanced synced lyrics supported.",
+    "readMoreAboutLrc": "$t(common.readMoreAboutTitle, {\"title\": \"LRC format\"})",
+    "avoidUnsyncedOnSyncedLyricsTab": "Avoid entering unsynchronized lyrics in the synchronized lyrics tab.",
+    "avoidSyncedOnUnsyncedLyricsTab": "Avoid entering synchronized lyrics in the unsynchronized lyrics tab.",
+    "pendingLyricsSavesAvailable": "There are pending lyrics to be saved to this song. They will be saved and visible here after the current song is finished playing.",
+    "downloadLyrics": "Download lyrics",
+    "downloadSyncedLyrics": "Download synced lyrics",
+    "musixmatchNotEnabled": "'You have to enable Musixmatch Lyrics from Settings to use this feature."
+  },
+
+  "miniPlayer": {
+    "alwaysOnTopEnabled": "Always on top: ON",
+    "alwaysOnTopDisabled": "Always on top: OFF"
+  },
+
+  "time": {
+    "second_one": "second",
+    "second_other": "seconds",
+    "minute_one": "minute",
+    "minute_other": "minutes",
+    "hour_one": "hour",
+    "hour_other": "hours",
+    "day_one": "day",
+    "day_other": "days",
+    "month_one": "month",
+    "month_other": "months",
+    "year_one": "year",
+    "year_other": "years",
+    "secondWithCount": "{{count}} $t(time.second, {\"count\":{{count}}})",
+    "minuteWithCount": "{{count}} $t(time.minute, {\"count\":{{count}}})",
+    "hourWithCount": "{{count}} $t(time.hour, {\"count\":{{count}}})",
+    "dayWithCount": "{{count}} $t(time.day, {\"count\":{{count}}})",
+    "monthWithCount": "{{count}} $t(time.month, {\"count\":{{count}}})",
+    "yearWithCount": "{{count}} $t(time.year, {\"count\":{{count}}})"
+  },
+
+  "elapsedTime": {
+    "second_one": "{{count}} second ago",
+    "second_other": "{{count}} seconds ago",
+    "minute_one": "{{count}} minute ago",
+    "minute_other": "{{count}} minutes ago",
+    "hour_one": "{{count}} hour ago",
+    "hour_other": "{{count}} hours ago",
+    "day_one": "{{count}} day ago",
+    "day_other": "{{count}} days ago",
+    "month_one": "{{count}} month ago",
+    "month_other": "{{count}} months ago",
+    "year_one": "{{count}} year ago",
+    "year_other": "{{count}} years ago"
+  },
+
+  "month": {
+    "january": "January",
+    "february": "February",
+    "march": "March",
+    "april": "April",
+    "may": "May",
+    "june": "June",
+    "july": "July",
+    "august": "August",
+    "september": "September",
+    "october": "October",
+    "november": "November",
+    "december": "December"
+  },
+
+  "data": {
+    "byteWithCount_one": "{{count}} byte",
+    "byteWithCount_other": "{{count}} bytes"
+  },
+
+  "sideBar": {
+    "home": "Home",
+    "search": "Search"
+  },
+
+  "renamePlaylistPrompt": {
+    "renamePlaylistWithName": "Rename `{{name}}` playlist",
+    "playlistName": "Playlist name"
+  },
+
+  "newPlaylistPrompt": {
+    "addPlaylistSuccess": "Playlist added successfully.",
+    "playlistNameEmpty": "Playlist name is required",
+    "addNewPlaylist": "Add new playlist"
+  },
+
+  "confirmDeletePlaylistsPrompt": {
+    "playlistsDeletedWithCount": "$t(common.playlistWithCount, {\"count\":{{count}}}) deleted.",
+    "confirmPlaylistDeleteWithCount": "Confirm deleting $t(common.playlistWithCount, {\"count\":{{count}}})",
+    "message_one": "Removing this playlist will remove the connection between songs that you organized into this playlist. You won't be able to access this playlist again if you decide to delete it.",
+    "message_other": "Removing these playlists will remove the connection between songs that you organized into these playlists. You won't be able to access these playlists again if you decide to delete it.",
+    "modificationNotice": "Performing this action will affect these files: "
+  },
+
+  "resetAppConfirmationPrompt": {
+    "confirmAppReset": "Confirm app reset",
+    "message": "Resetting the app removes all user data, including data related to songs, favorites, preferences, applied settings, etc., but NOT the songs themselves. Please note that this action is <span>IRREVERSIBLE</span>.",
+    "restartAfterReset": "Nora will restart after the reset.",
+    "systemPlaylistsRemovalProhibited": "You cannot remove playlists like History or Favorites."
+  },
+
+  "addSongsToPlaylistsPrompt": {
+    "songsAddedToPlaylists": "Added $t(common.songWithCount, {\"count\":{{count}}}) to $t(common.playlistWithCount, {\"count\":{{playlistCount}}})",
+    "selectPlaylistsToAdd": "Select playlists to add $t(common.songWithCount, {\"count\":{{count}}})",
+    "duplicationNotice": "When adding multiple songs to playlists, songs that are already in selected playlists will be ignored."
+  },
+
+  "blacklistSongConfirmPrompt": {
+    "title": "Confirm blacklisting $t(common.songWithCount, {\"count\":{{count}}}) from the library",
+    "message_one": "You are about to blacklist this song from the library. You can restore it again by right-clicking it and clicking '$t(song.deblacklist)'. Your data related to this song won't be affected by this action.",
+    "message_other": "You are about to blacklist these songs from the library. You can restore them again by right-clicking and clicking '$t(song.deblacklist)'. Your data related to these songs won't be affected by this action.",
+    "effectTitle": "What blacklisting a song does",
+    "effect1": "Will appear greyed-out in the library with a '<span/>' symbol.",
+    "effect2": "Won't be added to the queue automatically, not even through <span>'$t(common.shuffleAndPlay)'</span> or<span>'$t(common.playAll)'</span>, unless you explicitly add them.",
+    "effect3": "Can still be played by double-clicking, or by using either <span>'$t(common.play)'</span> or <span>'$t(common.playNext)'.</span>",
+    "songsBlacklisted": "$t(common.songWithCount, {\"count\":{{count}}}) blacklisted and removed from the library"
+  },
+
+  "blacklistFolderConfirmPrompt": {
+    "title": "Confirm blacklisting $t(common.folderWithCount, {\"count\":{{count}}}) from the library",
+    "message_one": "You are about to blacklist this folder. You can restore it again from the Folders page by right-clicking and selecting '$t(song.deblacklist)'. Your data related to this folder won't be affected by this action.",
+    "message_other": "You are about to blacklist these folders. You can restore them again from the Folders page by right-clicking and selecting '$t(song.deblacklist)'. Your data related to these folders won't be affected by this action.",
+    "effectTitle": "What blacklisting a folder does",
+    "effect1": "Will appear greyed out in the library with '<span/>' symbol.",
+    "effect2": "Songs linked to this folder will also be blacklisted.",
+    "effectTitle2": "What happens to songs linked to a blacklisted folder",
+    "folderBlacklisted": "$t(common.folderWithCount, {\"count\":{{count}}}) blacklisted."
+  },
+
+  "deleteSongFromSystemConfirmPrompt": {
+    "title_one": "Delete `{{title}}` from system",
+
+    "title_other": "Delete $t(common.songWithCount, {\"count\":{{count}}}) from system",
+    "permanentlyDeleteFromSystem": "Permanently delete from the system",
+    "message_one": "You will lose this song from your system and may not be able to recover it again if you select '$t(deleteSongFromSystemConfirmPrompt.permanentlyDeleteFromSystem)' from system option.",
+    "message_other": "You will lose these songs from your system and may not be able to recover them again if you select '$t(deleteSongFromSystemConfirmPrompt.permanentlyDeleteFromSystem)' from system option.",
+    "modificationNotice": "Proceeding this action affects these files :",
+    "deleteSong": "Delete song",
+    "songPermanentlyDeleted": "$t(common.songWithCount, {\"count\":{{count}}}) removed from the system.",
+    "songMovedToBin": "$t(common.songWithCount, {\"count\":{{count}}}) moved to the recycle Bin."
+  },
+
+  "addMusicFoldersPrompt": {
+    "title": "Select folders to add",
+    "emptyMessage1": "Seems like you didn't select any folders.",
+    "emptyMessage2": "Choose some folders from your system, and they will appear here for you to further customize them.",
+    "chooseFolders": "Choose folders",
+    "addSelectedFolders": "Add selected folders",
+    "noFoldersSelected": "No folders selected. (Must have one parent folder)"
+  },
+
+  "removeFolderConfirmationPrompt": {
+    "title": "Confirm to remove `{{folderName}}` folder",
+    "message": "Are you sure that you want to remove this folder from the music library? This will remove all the data related to this folder including songs data from the music library. The files on your system will remain untouched.",
+    "removeFolder": "Remove folder"
+  },
+
+  "lyricsEditorHelpPrompt": {
+    "title": "How to use Nora's lyrics editor",
+    "subTitle1": "How to start using the editor?",
+    "subTitle1Message": " <ol><li>Play the song that you are trying to edit lyrics of. (If you are not in the correct song, app will prevent adding incorrect metadata to lyrics lines.)</li><li>Click on the page area to get focus to the page. (Page focus is required for the page-specific keyboard shortcuts to work.)</li><li>Start the song from the begining. If you want more control over the playback, set to repeat the current song.</li><li>When the voice of the song is saying the lyrics line, press <ShortcutButton>$t(appShortcutsPrompt.enterKey)</ShortcutButton> to highlight the next lyrics line and add the current time to start tag.</li><li>Continue until the last lyrics line.</li></ol>",
+    "subTitle2": "What are the keyboard shortcuts I can use in the Lyrics Editor?",
+    "subTitle2Message": "Go to the <Button>Shortcuts Prompt</Button> to see the relevant shortcuts that can be used in the Lyrics Editor.",
+    "subTitle3": "I missed a lyrics line?",
+    "subTitle3Message": "<ol><li>Pause the song.</li><li>Locate the relevant lyrics line.</li><li>Click the <ShortcutButton>Edit</ShortcutButton> button below that line and make the necessary modifications.</li><li>After the modifications, click <ShortcutButton>$t(lyricsEditingPage.finishEditing)</ShortcutButton> to complete the modifications.</li></ol>",
+    "subTitle4": "I added wrong data to the wrong line?"
+  },
+
+  "lyricsEditorSavePrompt": {
+    "lyricsUpdateSuccess": "Lyrics successfully updated.",
+    "saveEditedLyrics": "Save edited lyrics",
+    "copyLyrics": "Copy lyrics",
+    "saveLyricsToSong": "Save lyrics to song",
+    "saveLyricsNotSupported": "Nora currently doesn't support saving lyrics to songs in '{{format}}' audio format.",
+    "saveLyricsFormatInfo": "* Lyrics are saved in <Hyperlink>LRC format</Hyperlink>.",
+    "readAboutLrcFormat": "Read more about the LRC format"
+  },
+
+  "lyricsEditorSettingsPrompt": {
+    "lyricsEditorSettings": "Lyrics editor settings",
+    "editNextAndCurrentStartAndEndTagsAutomaticallyDescription": "Change the start time tag of the next lyrics line when you edit the end time tag of the current lyrics line and vice versa automatically.",
+    "editNextAndCurrentStartAndEndTagsAutomatically": "Edit next line's start tag with the current line's end tag and vice versa automatically.",
+    "lyricOffsetInputDescription": "Select a negative or positive offset to add to lyrics lines when editing them automatically.",
+    "lyricOffsetInput": "Offset (+ or -)"
+  },
+
+  "pageFocusPrompt": { "pageNotFocused": "Page not focused." },
+
+  "releaseNotesPrompt": {
+    "latestVersion": "You have the latest version.",
+    "oldVersion": "<br/><span>You do not have the latest version.</span> <Hyperlink>Update now</Hyperlink>",
+    "outdatedChangelogNotice": "You may be viewing an outdated changelog.",
+    "versionCheckError": "<br/><span>Failed to check for new updates. Something is wrong in our end.<div>$t(releaseNotesPrompt.outdatedChangelogNotice)</div></span>",
+    "versionCheckNetworkError": "<br/><span> We couldn't check for new updates. Check you network connection and try again.<div>$t(releaseNotesPrompt.outdatedChangelogNotice)</div></span>",
+    "noraReleases": "Nora releases",
+    "changelog": "Changelog",
+    "doNotRemindThisVersionUpdate": "Do not remind me again about this version of the app.",
+    "current": "Current",
+    "latest": "Latest",
+    "newFeaturesAndUpdates": "New features and updates",
+    "fixesAndImprovements": "Fixes and improvements",
+    "issuesAndBugs": "Known issues and bugs",
+    "developerUpdates": "Developer updates"
+  },
+
+  "appShortcutsPrompt": {
+    "inAppShortcuts": "In app shortcuts",
+
+    "mediaPlayback": "Media playback",
+    "playPause": "Play / Pause",
+    "toggleMute": "Toggle mute",
+    "nextSong": "Next song",
+    "prevSong": "Previous song",
+    "tenSecondsForward": "10 seconds forward",
+    "tenSecondsBackward": "10 seconds backward",
+    "upVolume": "Increase volume",
+    "downVolume": "Decrease volume",
+    "toggleShuffle": "Toggle queue shuffle",
+    "toggleRepeat": "Toggle queue repeat",
+    "toggleFavorite": "Toggle favorite",
+    "upPlaybackRate": "Increase playback rate by 0.05x",
+    "downPlaybackRate": "Decrease playback rate by 0.05x",
+    "resetPlaybackRate": "Reset playback rate to 1x",
+
+    "navigation": "Navigation",
+    "goHome": "Go to Home",
+    "goBack": "Go back",
+    "goForward": "Go forward",
+    "openMiniPlayer": "Open Mini Player",
+    "goToLyrics": "Go to Lyrics",
+    "goToQueue": "Go to Current queue",
+    "goToSearch": "Go to Search",
+
+    "selections": "Selections",
+    "selectMultipleItems": "Select multiple items",
+
+    "lyrics": "Lyrics",
+    "playNextLyricsLine": "Play the next lyrics line",
+    "playPrevLyricsLine": "Play the previous lyrics line",
+
+    "lyricsEditor": "Lyrics editor",
+    "selectNextLyricsLine": "Select the next lyrics line",
+    "selectPrevLyricsLine": "Select the previous lyrics line",
+    "selectCustomLyricsLine": "Select a custom lyrics line",
+
+    "otherShortcuts": "Other shortcuts",
+    "toggleTheme": "Toggle app theme",
+    "toggleMiniPlayerAlwaysOnTop": "Toggle Mini Player always on top",
+    "reload": "Reload",
+    "openDevtools": "Open devtools",
+    "openAppShortcutsPrompt": "Open App Shortcuts prompt",
+
+    "enterKey": "Enter",
+    "spaceKey": "Space",
+    "ctrlKey": "Ctrl",
+    "shiftKey": "Shift",
+    "altKey": "Alt",
+    "homeKey": "Home",
+    "rightArrowKey": "Right arrow",
+    "leftArrowKey": "Left arrow",
+    "upArrowKey": "Up arrow",
+    "downArrowKey": "Down arrow",
+
+    "mouseClick": "Mouse click",
+    "doubleClick": "Double-click"
+  },
+
+  "clearLocalStoragePrompt": {
+    "title": "Confirm clearing local storage data",
+    "description": "This process will clear any corrupted local storage data in Nora and revert it back to the default settings.",
+    "effect": "<p>Proceeding this action will affect the following data: </p><ul><li>Most preference settings in Nora</li><li>Playback settings such as currently playing song, volume etc.</li><li>Current queue data</li><li>Ignored suggestions data such as featuring artists, separate artists and duplicates</li><li>Page sorting data</li><li>Equalizer data</li><li>Lyrics editor settings</li></ul>",
+    "restartNotice": "Nora will restart after the process."
+  },
+
+  "musixmatchDisclaimerPrompt": {
+    "title": "Disclaimer - Musixmatch Lyrics",
+    "message": "<li> Musixmatch Lyrics is added as an evaluation feature to this software and could be removed at any time.</li><li>Nora is in no way affiliated with, authorised, maintained, sponsored or endorsed by Musixmatch Lyrics or any of its affiliates or subsidiaries.</li><li>The maintainers of this application call upon the personal responsibility of its users to use this feature in a fair way, as it is intended to be used by obeying the copyrights implemented by Musixmatch Lyrics.</li>",
+    "implementationNotice": "Implementation from Fashni's <Hyperlink/>.",
+    "hyperlinkTitle": "MxLRC Github repository",
+    "contactAboutComplaints": "If you have any complaints, you can contact me through the Nora Discord server, or through my <Hyperlink>email</Hyperlink>."
+  },
+
+  "musixmatchSettingsPrompt": {
+    "title": "Musixmatch settings",
+    "message": "<li>Musixmatch requires a user token to provide its service properly.</li><li>Musixmatch can sometimes fail to show lyrics due to prolonged use of the service from the same token.</li><li>Follow the guide from <Hyperlink>Spicetify Wiki</Hyperlink> to get a new Musixmatch token.</li>",
+    "showToken": "Show token",
+    "hideToken": "Hide token",
+    "updateToken": "Update token",
+    "tokenUpdateSuccess": "Token updated successfully.",
+    "tokenUpdateFailed": "Failed to update the token.",
+    "tokenMissingCharacters": "TOKEN should be a string with 54 characters. ({{count}} more characters required).",
+    "tokenIncorrectCharacters": "TOKEN should only contain alpha-numeric characters.",
+    "savedTokenAvailableMessage": "<Title><span/> A saved token available.</Title><p> A valid Musixmatch token saved by the user is already available in Nora.</p> <p> You only need to change the token if the service is not functioning properly.</p>"
+  },
+
+  "customizeSelectedMetadataPrompt": {
+    "selected": "Selected",
+    "select": "Select",
+    "title": "Customize downloaded metadata for `{{title}}`",
+    "selectArtwork": "Select an artwork",
+    "noArtworksFound": "No artworks found",
+    "customizeOtherMetadata": "Customize other metadata",
+    "syncedLyricsAvailable": "Synced lyrics available",
+    "unsyncedLyricsAvailable": "Unsynced lyrics available",
+    "addOnlySelected": "Add only selected",
+    "addAll": "Add all"
+  },
+
+  "resetTagsToDefaultPrompt": {
+    "changed": "Changed",
+    "title": "Confirm before resetting song data to default",
+    "description": "Are you sure you want to reset the song data? You will lose the data you edited on this screen.",
+    "resetToDefault": "Reset to default"
+  },
+
+  "songMetadataResultSelectPrompt": {
+    "title": "Results related to <span/>"
+  },
+
+  "errorPrompt": {
+    "title": "An error occurred",
+    "sendErrorInfo": "Please send us <Hyperlink1>feedback</Hyperlink1> to improve the app or <Hyperlink2>create an issue</Hyperlink2> on Github."
+  },
+
+  "openLinkConfirmPrompt": {
+    "description": "You are trying to open a link that will take you to <span/>.<br/> This link will be opened from your default browser.",
+    "doNotVerifyLink": "Do not verify when trying to open a link.",
+    "openLink": "Open link"
+  },
+
+  "songUnplayableErrorPrompt": {
+    "title": "Couldn't play the song",
+    "description": "Seems like we can't play that song. Please check whether the selected song is available in your system and accessible by the app."
+  },
+
+  "unsupportedFileMessagePrompt": {
+    "title": "Unsupported audio file",
+    "description": "You are trying to open a file with a <span/> extension, which is not supported by this app.<br/> Currently, we only support following audio formats. <div/>"
+  },
+
+  "duplicateArtistsSuggestion": {
+    "message": "<div><p>Are <span/> the same artist?</p><p>If they are, you can link content of them into a single artist, or you can ignore this suggestion.</p></div>",
+    "linkToArtist": "Link to {{name}}"
+  },
+
+  "separateArtistsSuggestion": {
+    "message": "<div><p>Are <span/> {{count}} separate artists?</p><p>If they are, you can organize them by selecting them as separate artists, or you can ignore this suggestion.</p></div>",
+    "separateAsArtists": "Separate as {{count}} artists"
+  },
+
+  "featArtistsSuggestion": {
+    "message_one": "<p>Is <span/> an artist featuring in this song?</p><p>If so, you can add that artist as an artist of the song, or you can ignore this suggestion.</p>",
+    "message_other": "<p>Are <span/> {{count}} artists featuring in this song?</p><p>If so, you can add those artists as artists of the song, or you can ignore this suggestion.</p>",
+    "featArtistsTitleReset": "Remove featuring artists information from song title after adding artists to the song.",
+    "addArtistsToSong": "Add $t(common.artistWithCount, {\"count\":{{count}}}) to the song",
+    "editInMetadataEditingPage": "Edit in the metadata editing page",
+    "modificationNotice": "Keep in mind that adding featuring artists to the song will update the song data in the library as well as the song metadata."
+  },
+
+  "biography": {
+    "readMore": "Read more...",
+    "readMoreInLastFm": "Read more in LastFM",
+    "aboutName": "About <span/>",
+    "goToTagInLastFm": "Go to {{name}} tag in LastFM"
+  },
+
+  "notifications": {
+    "clearAll": "Clear all",
+    "playingNext": "`{{title}}` will be played next.",
+    "songBlacklisted": "`{{title}}` is blacklisted.",
+    "playingNextSongsWithCount": "$t(common.songWithCount, {\"count\":{{count}}}) will be played next.",
+    "addedToQueue": "Added $t(common.songWithCount, {\"count\":{{count}}}) to the queue",
+    "suggestionIgnored": "Suggestion ignored.",
+    "songRestoreSuccess": "Song restored successfully.",
+    "songDataUpdateFailed": "Song data update failed.",
+    "noSongDataEdits": "You didn't change any song data.",
+    "selectASongToPlay": "Select a song to play",
+    "alreadyInPage": "You are already in the current page.",
+    "playbackRateChanged": "Playback rate changed to {{val}} x",
+    "playbackRateReset": "Playback rate has been reset to 1x",
+    "playbackPausedDueToSongDeletion": "Current song playback paused because the song was deleted.",
+    "languageChanged": "Changed app language successfully."
+  },
+
+  "backend": {
+    "RESYNC_SUCCESSFUL": "Library resync successfull.",
+    "RESET_SUCCESSFUL": "App reset successfully, now restarting.",
+    "RESET_FAILED": "Resetting the app failed. Reloading the app now.",
+    "APP_THEME_CHANGE": "System theme changed to {{theme}}",
+    "SONG_REMOVE_PROCESS_UPDATE": "Removed {{value}} out of {{total}} songs.",
+    "OPEN_SONG_IN_EXPLORER_FAILED": "Opening song file in explorer failed because song couldn't be found in the library.",
+    "PENDING_METADATA_UPDATES_SAVED": "Successfully saved pending metadata updates of `{{title}}`.",
+    "METADATA_UPDATE_FAILED": "Metadata update failed. {{message}}",
+    "SONG_EXT_NOT_SUPPORTED_FOR_LYRICS_SAVES": "Lyrics cannot be saved because current song extension ({{ext}}) is not supported for modifying metadata.",
+    "LASTFM_LOGIN_SUCCESS": "You successfully logged in to LastFM.",
+    "AUDIO_PARSING_PROCESS_UPDATE": "{{value}} completed out of {{total}} songs.",
+    "SONG_PALETTE_GENERATING_PROCESS_UPDATE": "Generating palettes for {{value}} out of {{total}} songs.",
+    "GENRE_PALETTE_GENERATING_PROCESS_UPDATE": "Generating palettes for {{value}} out of {{total}} genres.",
+    "LYRICS_FIND_FAILED": "We couldn't find lyrics for `{{title}}`",
+    "LYRICS_TRANSLATION_SUCCESS": "Lyrics translated successfully",
+    "LYRICS_CONVERT_SUCCESS": "Lyrics converted successfully",
+    "RESET_CONVERTED_LYRICS_SUCCESS": "Reset lyrics successfully",
+    "LYRICS_TRANSLATION_FAILED": "Failed to translate lyrics",
+    "LYRICS_TRANSLATION_TO_SAME_SOURCE_LANGUAGE": "Lyrics were requested to be translated to the same source language '{{language}}'",
+    "LYRICS_CONVERT_FAILED": "Failed to convert lyrics",
+    "RESET_CONVERTED_LYRICS_FAILED": "Failed to reset lyrics",
+    "MUSIC_FOLDER_DELETED": "`{{name}}` folder got deleted from the system. $t(common.songWithCount, {\"count\":{{count}}}) related to that folder will be removed from the library.",
+    "EMPTY_MUSIC_FOLDER_DELETED": "`{{name}}` folder got deleted from the system. No songs found related to the folder. Library will be unaffected.",
+    "WHITELISTING_FOLDER_FAILED_DUE_TO_BLACKLISTED_PARENT_FOLDER": "Couldn't whitelist `{{folderName}}` folder because its parent folder '{{parentFolderName}}' is also blacklisted. Whitelist the parent folder to whitelist this folder.",
+    "WHITELISTING_SONG_FAILED_DUE_TO_BLACKLISTED_DIRECTORY": "'{{songName}}' cannot be whitelisted because its directory '{{directoryName}}' is also blacklisted. Whitelist the directory to whitelist this song.",
+    "SONG_WHITELISTED": "$t(common.songWithCount, {\"count\":{{count}}}) restored from the blacklist.",
+    "ARTWORK_SAVED": "Saved the artwork to the request location.",
+    "DESTINATION_NOT_SELECTED": "No save destination selected.",
+    "ARTWORK_SAVE_FAILED": "Failed to save the artwork.",
+    "PLAYBACK_FROM_UNKNOWN_SOURCE": "You are playing a song outside from your library.",
+    "ARTIST_DISLIKE": "`{{name}}` has been removed from favorites.",
+    "ARTIST_LIKE": "`{{name}}` has been added to favorites.",
+    "SONG_DISLIKE": "`{{name}}` has been removed from favorites.",
+    "SONG_LIKE": "`{{name}}` has been added to favorites.",
+    "SONG_DELETED": "`{{name}}` song deleted from the system.",
+    "FOLDER_PARSED_FOR_DIRECTORIES": "$t(folder.directoryCount, {\"count\":{{count}}}) found in $t(folder.selectedFolderCount, {\"count\":{{folderCount}}}).",
+    "NO_MORE_SONG_PALETTES": "No more palettes for songs to be generated.",
+    "NO_MORE_GENRE_PALETTES": "No more palettes for genres to be generated.",
+    "PARSE_FAILED": "`{{name}}` failed when trying to add the song to the library. Go to settings to resync the library.",
+    "PARSE_SUCCESSFUL": "`{{name}}` song added to the library.",
+    "LYRICS_SAVE_QUEUED": "Lyrics for `{{title}}` will be saved automatically.",
+    "LYRICS_SAVED_IN_LRC_FILE": "`Lyrics for this song with '{{ext}}' extension will be saved in an LRC file.",
+    "PENDING_LYRICS_SAVED": "Successfully saved pending lyrics of `{{title}}`.",
+    "ADDED_SONGS_TO_PLAYLIST": "Added $t(common.songWithCount, {\"count\":{{count}}}) to `{{name}}` successfully.",
+    "APPDATA_IMPORT_STARTED": "Started to import app data. Please wait...",
+    "APPDATA_IMPORT_SUCCESS": "Imported app data successfully.",
+    "APPDATA_IMPORT_SUCCESS_WITH_PENDING_RESTART": "$t(backend.APPDATA_IMPORT_SUCCESS) Restarting app in 5 seconds.",
+    "APPDATA_IMPORT_FAILED": "Failed to import app data.",
+    "APPDATA_IMPORT_FAILED_DUE_TO_MISSING_FILES": "$t(backend.APPDATA_IMPORT_FAILED) Missing required files in the selected folder.",
+    "APPDATA_EXPORT_STARTED": "Started to export app data. Please wait...",
+    "APPDATA_EXPORT_SUCCESS": "Exported app data successfully.",
+    "APPDATA_EXPORT_FAILED": "Error occurred when exporting app data.",
+    "PLAYLIST_EXPORT_SUCCESS": "Exported `{{name}}` playlist successfully.",
+    "PLAYLIST_EXPORT_FAILED": "Error occurred when exporting `{{name}}` playlist.",
+    "PLAYLIST_IMPORT_SUCCESS": "Imported `{{name}}` playlist successfully.",
+    "PLAYLIST_IMPORT_FAILED": "Failed to import the playlist.",
+    "PLAYLIST_IMPORT_FAILED_DUE_TO_SONGS_OUTSIDE_LIBRARY": "Found $t(common.songWithCount, {\"count\":{{count}}}) outside the library when importing a playlist which is not supported.",
+    "PLAYLIST_IMPORT_FAILED_DUE_TO_INVALID_FILE_DATA": "Failed to import the playlist because user selected a file with invalid file data.",
+    "PLAYLIST_IMPORT_FAILED_DUE_TO_INVALID_FILE_EXTENSION": "Playlist import failed because the selected file type wasn't '.m3u8'.",
+    "PLAYLIST_IMPORT_TO_EXISTING_PLAYLIST": "Imported $t(common.songWithCount, {\"count\":{{count}}}) to the existing `{{name}}` playlist.",
+    "PLAYLIST_IMPORT_TO_EXISTING_PLAYLIST_FAILED": "Error occurred when importing songs to an existing playlist.",
+    "PLAYLIST_CREATION_FAILED": "Failed to create a playlist.",
+    "PLAYLIST_RENAME_SUCCESS": "Playlist renamed successfully.",
+    "PLAYLIST_NOT_FOUND": "Playlist not found.",
+    "SONG_REPARSE_SUCCESS": "Successfully reparsed `{{title}}`.",
+    "SONG_REPARSE_FAILED": "Error occurred when re-parsing the song."
+  },
+
+  "discordrpc": {
+    "noraOnGitHub": "Nora on GitHub",
+    "untitledSong": "An untitled song",
+    "unknownArtist": "an unknown artist",
+    "playingASong": "Playing a song"
+  }
 }

--- a/src/renderer/src/assets/locales/pl/pl.json
+++ b/src/renderer/src/assets/locales/pl/pl.json
@@ -1,1124 +1,1121 @@
 {
-	"common": {
-		"song_one": "utwór",
-		"song_other": "Utwory",
-		"playlist_one": "playlista",
-		"playlist_other": "Playlisty",
-		"artist_one": "wykonawca",
-		"artist_other": "Wykonawcy",
-		"album_one": "album",
-		"album_other": "Albumy",
-		"genre_one": "gatunek",
-		"genre_other": "Gatunki",
-		"folder_one": "folder",
-		"folder_other": "Foldery",
-		"songWithCount_one": "{{count}} utwór",
-		"songWithCount_other": "{{count}} utworów",
-		"playlistWithCount_one": "{{count}} playlista",
-		"playlistWithCount_other": "{{count}} playlist",
-		"artistWithCount_one": "{{count}} wykonawca",
-		"artistWithCount_other": "{{count}} wykonawców",
-		"albumWithCount_one": "{{count}} album",
-		"albumWithCount_other": "{{count}} albumów",
-		"genreWithCount_one": "{{count}} gatunek",
-		"genreWithCount_other": "{{count}} gatunków",
-		"folderWithCount_one": "{{count}} folder",
-		"folderWithCount_other": "{{count}} folderów",
-		"subFolderWithCount_one": "{{count}} podfolder",
-		"subFolderWithCount_other": "{{count}} podfolderów",
-
-		"selectionWithCount_one": "Wybrano {{count}}",
-		"selectionWithCount_other": "Wybrano {{count}}",
-
-		"shownWithCount": "Wyświetlono {{count}}",
-
-		"unknownTitle": "Nieznany tytuł",
-		"unknownArtist": "Nieznany wykonawca",
-		"unknownAlbum": "Nieznany album",
-		"unknownGenre": "Nieznany gatunek",
-		"unknownFolder": "Nieznany folder",
-		"unknownLyricsProvider": "Nieznany dostawca tekstu",
-
-		"songTitle": "Tytuł utworu",
-		"duration": "Czas trwania",
-		"albumArtists": "Wykonawcy albumu",
-		"albumTrackNo": "Numer utworu na albumie",
-		"releasedYear": "Rok wydania",
-		"songAddedOn": "Data dodania utworu",
-		"lastModifiedOn": "Ostatnia modyfikacja",
-		"sampleRate": "Częstotliwość próbkowania",
-		"bitRate": "Bitrate",
-		"noOfAudioChannels": "Liczba kanałów audio",
-		"channelWithCount_one": "{{count}} kanał (Mono)",
-		"channelWithCount_other": "{{count}} kanałów (Stereo)",
-		"songLocation": "Lokalizacja pliku",
-		"lyrics": "Tekst utworu",
-		"syncedLyrics": "Tekst zsynchronizowany",
-		"unsyncedLyrics": "Tekst niezsynchronizowany",
-
-		"play": "Odtwórz",
-		"playNext": "Odtwórz jako następne",
-		"playNextAll": "Dodaj wszystko jako następne",
-		"shuffleAndPlay": "Losuj i odtwarzaj",
-		"shuffleAndPlayAll": "Losuj i odtwarzaj wszystko",
-		"playAll": "Odtwórz wszystko",
-		"addToQueue": "Dodaj do kolejki",
-		"removeFromQueue": "Usuń z kolejki",
-		"addSongsToQueue": "Dodaj utwory do kolejki",
-		"createAQueue": "Utwórz kolejkę",
-		"info": "Informacje",
-		"select": "Wybierz",
-		"unselect": "Odznacz",
-		"selectAll": "Zaznacz wszystko",
-		"unselectAll": "Odznacz wszystko",
-		"showAll": "Pokaż wszystko",
-		"cancel": "Anuluj",
-		"search": "Szukaj",
-		"help": "Pomoc",
-		"copy": "Kopiuj",
-
-		"sortBy": "Sortuj według",
-		"filterBy": "Filtruj według",
-		"moreOptions": "Więcej opcji",
-		"title": "Tytuł",
-		"suggestion": "Sugestia",
-		"hideSuggestion": "Ukryj sugestię",
-		"showSuggestion": "Pokaż sugestię",
-		"and": "i",
-		"ignore": "Ignoruj",
-		"goBack": "Wstecz",
-		"saveArtwork": "Zapisz okładkę",
-		"readMoreAboutTitle": "Czytaj więcej o `{{title}}`",
-		"doNotShowThisMessageAgain": "Nie pokazuj tego ponownie.",
-		"artistConflictResolved": "Konflikt wykonawców rozwiązany pomyślnie.",
-		"featArtistSuggestionResolved": "Sugestia dotycząca gościnnie występujących artystów rozwiązana pomyślnie.",
-		"hasInternet": "Jesteś połączony(a) z internetem.",
-		"noInternet": "Nie jesteś połączony(a) z internetem.",
-		"newUpdateAvailable": "Dostępna jest nowa aktualizacja aplikacji.",
-		"checkingForUpdates": "Sprawdzanie aktualizacji...",
-		"updateCheckError": "Wystąpił błąd podczas sprawdzania aktualizacji.",
-		"updateCheckErrorNoInternet": "$t(common.updateCheckError) $t(common.noInternet)",
-		"optionDisabled": "Ta opcja jest wyłączona.",
-		"somethingWentWrong": "Coś poszło nie tak.",
-		"details": "Szczegóły",
-		"restartApp": "Uruchom ponownie aplikację",
-		"ok": "OK",
-		"loading": "Wczytywanie"
-	},
-
-	"titleBar": {
-		"changeTheme": "Zmień motyw",
-		"goBack": "Wstecz (Alt + Strzałka w lewo)",
-		"goHome": "Strona główna (Alt + Home)",
-		"goForward": "Dalej (Alt + Strzałka w prawo)",
-
-		"minimize": "Minimalizuj",
-		"maximize": "Maksymalizuj",
-		"close": "Zamknij"
-	},
-
-	"player": {
-		"goToMainPlayer": "Przejdź do głównego odtwarzacza (Ctrl + N)",
-		"openInMiniPlayer": "Otwórz w Mini Odtwarzaczu (Ctrl + N)",
-		"openInFullScreen": "Otwórz na pełnym ekranie",
-		"likeDislike": "Oznacz jako lubiane albo nielubiane (Ctrl + H)",
-		"likeDislikeDisabled": "Oznaczanie jako lubiane albo nielubiane jest wyłączone, ponieważ odtwarzany utwór pochodzi z nieznanego źródła i tego nie wspiera.",
-		"prevSong": "Poprzedni utwór (Ctrl + Strzałka w lewo)",
-		"playPause": "Graj/Pauza (Spacja)",
-		"nextSong": "Następny utwór (Ctrl + Strzałka w prawo)",
-		"lyrics": "Tekst utworu (Ctrl + L)",
-		"shuffle": "Losuj (Ctrl + S)",
-		"repeat": "Powtarzaj (Ctrl + T)",
-		"muteUnmute": "Wycisz/Odcisz (Ctrl + M)",
-		"currentQueue": "Bieżąca kolejka (Ctrl + Q)",
-		"adjustPlaybackSpeed": "Dostosuj prędkość odtwarzania",
-		"showCurrentQueue": "Pokaż bieżącą kolejkę",
-		"showMiniPlayer": "Pokaż Mini Odtwarzacz",
-		"otherSettings": "Inne ustawienia",
-		"upNext": "NASTĘPNE: ",
-		"closeUpNext": "Zamknij 'NASTĘPNE'",
-		"by": "autorstwa",
-
-		"errorTitle": "Wystąpił błąd w odtwarzaczu.",
-		"errorMessage": "$t(player.errorTitle)<br /> Może to być wynik próby odtworzenia uszkodzonego utworu. <details/>",
-		"noErrorMessage": "Nie wygenerowano komunikatu o błędzie"
-	},
-
-	"sortTypes": {
-		"aToZ": "A do Z",
-		"zToA": "Z do A",
-		"dateAddedAscending": "Najstarsze",
-		"dateAddedDescending": "Najnowsze",
-		"releasedYearAscending": "Rok wydania (Rosnąco)",
-		"releasedYearDescending": "Rok wydania (Malejąco)",
-		"allTimeMostListened": "Najczęściej słuchane (Cały okres)",
-		"allTimeLeastListened": "Najrzadziej słuchane (Cały okres)",
-		"monthlyMostListened": "Najczęściej słuchane (Ten miesiąc)",
-		"monthlyLeastListened": "Najrzadziej słuchane (Ten miesiąc)",
-		"artistNameAscending": "Nazwa wykonawcy (A do Z)",
-		"artistNameDescending": "Nazwa wykonawcy (Z do A)",
-		"albumNameAscending": "Nazwa albumu (A do Z)",
-		"albumNameDescending": "Nazwa albumu (Z do A)",
-		"noOfSongsDescending": "Najwięcej utworów",
-		"noOfSongsAscending": "Najmniej utworów",
-		"blacklistedFolders": "Wykluczone foldery",
-		"whitelistedFolders": "Dozwolone foldery",
-		"mostLovedDescending": "Najbardziej lubiane",
-		"mostLovedAscending": "Najmniej lubiane",
-		"trackNoAscending": "Numer ścieżki (Rosnąco)",
-		"trackNoDescending": "Numer ścieżki (Malejąco)",
-		"addedOrder": "Kolejność dodania"
-	},
-
-	"filterTypes": {
-		"notSelected": "Nie wybrano",
-		"blacklistedSongs": "Wykluczone utwory",
-		"whitelistedSongs": "Dopuszczone utwory",
-		"favorites": "Ulubione",
-		"nonFavorites": "Nieulubione"
-	},
-
-	"equalizerPresets": {
-		"custom": "Własny",
-		"flat": "Płaski",
-		"acoustic": "Akustyczny",
-		"bassBooster": "Wzmocnienie basu",
-		"bassReducer": "Redukcja basu",
-		"classical": "Klasyczny",
-		"club": "Klubowy",
-		"dance": "Taneczny",
-		"deep": "Głęboki",
-		"electronic": "Elektroniczny",
-		"hipHop": "Hip Hop",
-		"jazz": "Jazz",
-		"latin": "Latino",
-		"live": "Na żywo",
-		"loudness": "Głośność",
-		"lounge": "Lounge",
-		"metal": "Metal",
-		"piano": "Pianino",
-		"pop": "Pop",
-		"reggae": "Reggae",
-		"rnb": "R&B",
-		"rock": "Rock",
-		"ska": "Ska",
-		"smallSpeakers": "Małe głośniki",
-		"soft": "Łagodne",
-		"softRock": "Soft Rock",
-		"spokenWord": "Głos",
-		"techno": "Techno",
-		"trebleBooster": "Wzmocnienie sopranów",
-		"trebleReducer": "Redukcja sopranów",
-		"vocalBooster": "Wzmocnienie wokalu"
-	},
-
-	"song": {
-		"showInFileExplorer": "Pokaż w Eksploratorze Plików",
-		"artwork": "Okładka utworu",
-		"selectedSongCount": "Wybrano {{count}} $t(common.song, {\"count\":{{count}}})",
-		"likeSong": "Dodaj do ulubionych",
-		"unlikeSong": "Usuń z ulubionych",
-		"toggleLikeSongs": "Dodaj/usuń utwory z ulubionych",
-		"addToPlaylists": "Dodaj do playlist(y)",
-		"goToAlbum": "Przejdź do albumu",
-		"editSongTags": "Edytuj tagi utworu",
-		"reparseSong": "Przeanalizuj utwór ponownie",
-		"blacklistSong_one": "Wyklucz utwór",
-		"blacklistSong_other": "Wyklucz utwory",
-		"deblacklist": "Przywróć z wykluczonych",
-		"delete": "Usuń z dysku",
-		"playingNext": "Zagrany jako następny:",
-		"playingNow": "Teraz odtwarzany",
-		"blacklisted": "Wykluczony",
-		"likedThisSong": "Polubiłeś(aś) ten utwór",
-		"dislikedThisSong": "Nie polubiłeś(aś) tego utworu"
-	},
-
-	"artist": {
-		"playAllSongs": "Odtwórz wszystkie utwory",
-		"toggleLikeArtists": "Dodaj/usuń wykonawców z ulubionych",
-		"likeArtist": "Dodaj wykonawcę do ulubionych",
-		"dislikeArtist": "Usuń wykonawcę z ulubionych",
-		"selectedArtistCount": "Wybrano {{count}} $t(common.artist, {\"count\":{{count}}})"
-	},
-
-	"folder": {
-		"toggleBlacklistFolder": "Przełącz wykluczenie folderu",
-		"blacklistFolder": "Wyklucz folder",
-		"selectedFolderCount": "Wybrano {{count}} $t(common.folder, {\"count\":{{count}}})",
-		"selectedParentFolderCount_one": "{{count}} wybrany folder nadrzędny",
-		"selectedParentFolderCount_other": "{{count}} wybranych folderów nadrzędnych",
-		"directoryCount_one": "{{count}} katalog",
-		"directoryCount_other": "{{count}} katalogów",
-		"selectedDirectoryCount_one": "{{count}} wybrany katalog",
-		"selectedDirectoryCount_other": "{{count}} wybranych katalogów"
-	},
-
-	"playlist": {
-		"changeArtwork": "Zmień okładkę",
-		"addArtwork": "Dodaj okładkę",
-		"playlistArtworkUpdateSuccess": "Pomyślnie zaktualizowano okładkę playlisty.",
-		"renamePlaylist": "Zmień nazwę playlisty",
-		"exportPlaylist": "Eksportuj playlistę",
-		"deleteSelectedPlaylists": "Usuń zaznaczone playlisty",
-		"deletePlaylist_one": "Usuń playlistę",
-		"deletePlaylist_other": "Usuń playlisty",
-		"selectedPlaylistCount": "Wybrano {{count}} $t(common.playlist, {\"count\":{{count}}})",
-		"empty": "Wygląda na to, że ta playlista jest pusta."
-	},
-
-	"album": {
-		"selectedAlbumCount": "Wybrano {{count}} $t(common.album, {\"count\":{{count}}})"
-	},
-
-	"genre": {
-		"selectedGenreCount": "Wybrano {{count}} $t(common.genre, {\"count\":{{count}}})"
-	},
-
-	"homePage": {
-		"empty": "Pusto tu...",
-		"emptyDescription": "Wygląda na to, że nie dodałeś(aś) jeszcze żadnych folderów z muzyką do Twojej biblioteki.",
-		"loading": "Chwilunia. Przygotowujemy wszystko dla Ciebie...",
-		"listenMoreToShowMetrics": "Przesłuchaj więcej utworów, aby zobaczyć dodatkowe statystyki.",
-
-		"recentlyAddedSongs": "Ostatnio dodane utwory",
-		"recentlyPlayedSongs": "Ostatnio odtwarzane utwory",
-		"recentArtists": "Ostatni wykonawcy",
-		"mostLovedSongs": "Najbardziej lubiane utwory",
-		"mostLovedArtists": "Najbardziej lubieni wykonawcy",
-
-		"openSongsWithNewestSortOption": "Otwiera „Utwory” z opcją sortowania „Najnowsze”.",
-		"openPlaybackHistory": "Otwiera playlistę 'Historia' z opcją sortowania „Kolejność dodania”",
-		"openFavoritesWithAllTimeMostListenedSortOption": "Otwiera playlistę „Ulubione” z opcją sortowania „Najczęściej słuchane (cały okres)”",
-
-		"noSongsAvailable": "Brak dostępnych utworów",
-		"stayCalm": "Prosze się uspokoić",
-		"favoritesAndRecaps": "Ulubione i Podsumowania"
-	},
-
-	"searchPage": {
-		"addFolder": "Dodaj folder",
-		"enablePredictiveSearch": "Włącz wyszukiwanie predykcyjne",
-		"disablePredictiveSearch": "Wyłącz wyszukiwanie predykcyjne",
-		"searchForAnything": "Szukaj czegokolwiek",
-		"searchForAnythingInLibrary": "Szukaj czegokolwiek w bibliotece",
-		"separateKeywords": "Użyj ' ; ', aby oddzielić frazy wyszukiwania.",
-		"allFilter": "Wszystkie",
-		"mostRelevant": "Najtrafniejsze",
-		"resultCount_one": "{{count}} wynik",
-		"resultCount_other": "{{count}} wyników",
-		"resultAndVisibleCount_other": "{{count}} wyników ($t(common.shownWithCount, {\"count\":{{noVisible}}}))",
-		"noResults": "Nie znaleziono niczego pasującego do Twojego zapytania.",
-		"recentSearchResultTooltipLabel": "Szukaj '{{value}}'",
-		"showingResultsFor": "Wyniki dla <span>'{{query}}'</span>",
-		"showingResultsForWithFilter": "Wyniki dla <span>'{{query}}'</span> w kategorii <span>{{filter}}</span>",
-
-		"a": "Szukaj czegokolwiek"
-	},
-
-	"songsPage": {
-		"loading": "Chwilunia. Przygotowujemy wszystko dla Ciebie...",
-		"empty": "Pusto tu..."
-	},
-
-	"artistsPage": {
-		"empty": "Pusto tu..."
-	},
-
-	"foldersPage": {
-		"addFolder": "Dodaj folder",
-		"musicFolders": "Foldery z muzyką",
-		"empty": "Brak dodanych folderów w Twojej bibliotece."
-	},
-
-	"playlistsPage": {
-		"createNewPlaylist": "Utwórz nową playlistę",
-		"importPlaylist": "Importuj playlistę",
-		"addPlaylist": "Dodaj playlistę",
-		"removeFromThisPlaylist": "Usuń z tej playlisty",
-		"removeSongFromPlaylistSuccess": "Usunięto `{{title}}` z '{{playlistName}}'",
-		"createdOn": "Utworzono {{val, datetime}}",
-		"clearSongHistoryConfirm": "Wyczyść historię odtwarzania",
-		"clearSongHistoryConfirmNotice": "Czy na pewno chcesz wyczyścić swoją historię odtwarzania? Tej operacji nie można cofnąć.",
-		"clearSongHistorySuccess": "Historia odtwarzania została wyczyszczona pomyślnie.",
-		"empty": "Nie utworzono jeszcze żadnych playlist.",
-
-		"favorites": "Ulubione",
-		"history": "Historia"
-	},
-
-	"albumsPage": {
-		"empty": "Pusto tu..."
-	},
-
-	"genresPage": {
-		"empty": "Pusto tu..."
-	},
-
-	"settingsPage": {
-		"settings": "Ustawienia",
-
-		"appearance": "Wygląd",
-		"changeTheme": "Zmień motyw aplikacji według własnych preferencji.",
-		"lightTheme": "Jasny motyw",
-		"darkTheme": "Ciemny motyw",
-		"systemTheme": "Motyw systemowy",
-
-		"enableImageBasedDynamicThemes": "Włącz motywy dynamiczne",
-		"enableImageBasedDynamicThemesDescription": "Zmieniaj motyw aplikacji dynamicznie na podstawie motywu okładki aktualnie odtwarzanego utworu.",
-
-		"language": "Język",
-		"languageDescription": "Wybierz język wyświetlania interfejsu Nora.",
-
-		"audioPlayback": "Odtwarzanie dźwięku",
-		"showRemainingSongDuration": "Pokaż pozostały czas utworu",
-		"showRemainingSongDurationDescription": "Wyświetla czas pozostały do końca utworu zamiast czasu odtwarzania, który upłynął.",
-		"playbackRate": "Prędkość odtwarzania",
-		"changePlaybackRate": "Zmień domyślną prędkość odtwarzania.",
-		"resetPlaybackRate": "Zresetuj do 1x",
-		"seekbarScrollInterval": "Zmień skok przewijania kółkiem myszy nad paskiem postępu i głośności.",
-		"second": "sekunda",
-		"second_other": "sekund",
-
-		"accounts": "Konta",
-		"integrateLastFm": "Zintegruj LastFM z Norą.",
-		"lastFmLogo": "Logo LastFM",
-		"lastFmConnected": "Połączono z LastFM",
-		"lastFmNotConnected": "Nie połączono z LastFM",
-		"loggedInAs": "Zalogowano jako",
-		"lastFmDescription1": "Połącz z LastFM, aby włączyć Scrobbling.",
-		"lastFmDescription2": "Scrobbling to sposób na wysyłanie informacji o muzyce, której użytkownik słucha.",
-		"lastFmDescription3": "Kiedy słuchasz utworu, LastFM go „Scrobbluje” i dodaje do Twojego profilu.",
-		"lastFmDescription4": "Ta funkcja wymaga połączenia z internetem.",
-		"authenticateAgain": "Uwierzytelnij ponownie",
-		"loginInBrowser": "Zaloguj się przez przeglądarkę",
-		"scrobblingDescription": "Włącz Scrobbling LastFM, aby wysyłać dane o tym jak słuchasz utworów.",
-		"enableScrobbling": "Włącz Scrobbling LastFM",
-		"sendFavoritesToLastFmDescription": "Wysyłaj informacje o ulubionych utworach do LastFM kiedy oznaczysz je jako polubione albo nielubiane.",
-		"sendFavoritesToLastFm": "Wysyłaj dane o ulubionych utworach",
-		"sendNowPlayingToLastFmDescription": "Wysyłaj informację o aktualnie odtwarzanym utworze do LastFM automatycznie po rozpoczęciu odtwarzania.",
-		"sendNowPlayingToLastFm": "Wysyłaj dane o aktualnie granym utworze",
-		"enableDiscordRpcDescription": "Zintegruj Discord Rich Presence z Norą",
-		"enableDiscordRpc": "Włącz Discord Rich Presence",
-
-		"doNotSaveLyricsAutomatically": "Nie zapisuj tekstów automatycznie",
-		"syncedLyricsOnly": "Tylko zsynchronizowane",
-		"saveEitherLyrics": "Zsynchronizowane lub zwykłe",
-		"lyrics": "Teksty utworów",
-		"enableMusixmatchLyricsDescription": "Włącz teksty utworów z Musixmatch, który dostarcza zsynchronizowane i niezsynchronizowane teksty Twoich piosenek na żądanie.",
-		"musixmatchDisclaimerNotice": "Włączenie i użycie tej funkcji oznacza, że zgadzasz się z <Button>Zastrzeżenieniami Musixmatch</Button> dotyczącymi tekstów utworów.",
-		"editMusixmatchSettings": "Edytuj ustawienia Musixmatch",
-		"enableMusixmatch": "Włącz teksty Musixmatch",
-		"musixmatchEnabled": "Teksty Musixmatch są włączone",
-		"saveLyricsAutomaticallyDescription": "Wybierz opcję automatycznego zapisywania tekstów utworów przy ich pobraniu.",
-		"saveLyricsAutomaticallyInfo": "Automatycznie pobrane teksty zostaną zapisane po zakończeniu utworu, aby uniknąć uszkodzenia plików.",
-		"saveLyricsInLrcFilesDescription": "Włącz zapisywanie tekstów w plikach LRC dla utworów, które wspierają edytowanie metadanych. W przeciwnym wypadku, Nora zapisze tekst w pliku LRC.",
-		"saveLyricsInLrcFiles": "Zapisuj teksty wspieranych utworów również w plikach LRC",
-		"autoTranslateLyricsDescription": "Włącz automatyczne tłumaczenie tekstów utworów na Twój wybrany język. Teksty zostaną automatycznie przetłumaczone nawet jeśli sa one już w takim samym języku, co przez Ciebie wybrany.",
-		"autoTranslateLyrics": "Automatyczne tłumaczenie tekstów",
-		"autoConvertLyricsDescription": "Włącz automatyczną transkrypcję tekstów na alfabet łaciński. Obecnie Nora obsługuje konwersję języka japońskiego, chińskiego i koreańskiego.",
-		"autoConvertLyrics": "Automatyczna konwersja tekstów",
-		"lrcFileCustomSaveLocationDescription": "Wybierz niestandardową lokalizację zapisu plików LRC, jeśli nie chcesz zapisywać ich w tym samym folderze, co powiązany utwór.",
-		"selectedCustomLocation": "Wybrana niestandardowa lokalizacja",
-		"setCustomLocation": "Ustaw niestandardową lokalizację",
-
-		"equalizer": "Korektor (Equalizer)",
-		"reset": "Zresetuj",
-
-		"defaultPage": "Strona startowa",
-		"changeDefaultPageDescription": "Zmień domyślną stronę, którą chcesz widzieć po uruchomieniu aplikacji.",
-
-		"preferences": "Preferencje",
-		"songIndexingDescription": "Włącza numerowanie utworów na stronach, nadając numer każdej piosence w zakładce Piosenki.",
-		"enableSongIndexing": "Włącz numerowanie utworów",
-		"showTrackNumberAsSongIndexDescription": "Pokazuje numer utworu przed nim samym na stronie albumów.",
-		"showTrackNumberAsSongIndex": "Pokaż numer utworu jako jego indeks",
-		"showArtistArtworkNearSongControlsDescription": "Pokazuje zdjęcie wykonawcy obok tytułu na panelu sterowania.",
-		"showArtistArtworkNearSongControls": "Pokaż dostępne zdjęcia wykonawców przy ich nazwach (w lewym dolnym rogu).",
-		"disableBackgroundArtworksDescription": "Wyłącza duże grafiki w tle na niektórych stronach.",
-		"disableBackgroundArtworks": "Wyłącz grafiki w tle",
-		"playlistArtworksDescription": "Zmień zachowanie grafik utworzonych z okładek utworów.",
-		"enablePlaylistArtworks": "Włącz grafiki utworzonych z okładek dla playlist",
-		"shuffleArtworkFromSongCovers": "Włącz losowanie grafik utworzonych z okładek utworów (zmienia się przy odświeżeniu).",
-
-		"accessibility": "Dostępność",
-		"reducedMotionDescription": "Usuwa animacje w aplikacji. Zmniejszy to też płynność aplikacji.",
-		"enableReducedMotion": "Włącz redukcję ruchu",
-
-		"performance": "Wydajność",
-		"removeAnimationOnBatteryDescription": "Usuwa animacje, gdy system działa na baterii.",
-		"removeAnimationOnBattery": "Wyłącz animacje na baterii",
-		"allowToPreventScreenSleepingDescription": "Pozwól Norze zapobiegać wygaszaniu ekranu w sytuacjach braku aktywności użytkownika, jak wyświetlanie tekstu utworu.",
-		"allowToPreventScreenSleeping": "Zapobiegaj usypianiu ekranu",
-
-		"startupAndWindowCustomization": "Uruchamianie i okna",
-		"autoLaunchAtStartDescription": "Automatycznie uruchamiaj Norę po zalogowaniu do systemu.",
-		"autoLaunchAtStart": "Uruchamiaj przy starcie systemu",
-		"hideWindowAtStartDescription": "Czy Nora ma być widoczna po uruchomieniu.",
-		"hideWindowAtStart": "Uruchamiaj zminimalizowane do zasobnika (Tray)",
-		"hideWindowOnCloseDescription": "Zachowanie przycisku zamknięcia okna.",
-		"hideWindowOnClose": "Minimalizuj do zasobnika po zamknięciu",
-
-		"storage": "Pamięć",
-		"storageDescription": "Zobacz jak Nora zarządza biblioteką i wykorzystuje miejsce na Twoim dysku.",
-
-		"fullStorageSpace": "Całkowite użycie",
-		"fullStorageOutOfUsage": "{{value}} z {{total}}",
-		"freeSpace": "Wolne miejsce",
-		"otherApplications": "Inne aplikacje",
-		"artworkCache": "Pamięć podręczna grafik",
-		"tempArtworkCache": "Tymczasowa pamięć grafik",
-		"databaseData": "Baza danych",
-		"songsData": "Dane utworów",
-		"artistsData": "Dane wykonawców",
-		"albumsData": "Dane albumów",
-		"playlistsData": "Dane playlist",
-		"palettesData": "Dane palet kolorów",
-		"genresData": "Dane gatunków",
-		"appLogs": "Logi aplikacji",
-		"userData": "Dane użytkownika",
-		"internalAppFiles": "Wewnętrzne pliki aplikacji",
-		"storageUseForLibraryData": "Użycie pamięci przez bibliotekę",
-		"otherAppFiles": "Pliki innych aplikacji",
-		"generated": "Wygenerowano",
-		"generateStorageMetrics": "Generuj statystyki pamięci",
-		"generateStorageMetricsAgain": "Generuj ponownie statystyki pamięci",
-		"noStorageMetrics": "Wygląda na to, że nie wygenerowano jeszcze statystyk pamięci.",
-		"storageMetricsGenerationDisclaimer": "Generowanie statystyk to stosunkowo wymagające obliczeniowo zadanie, co znaczy, że Nora może chwilowo nie odpowiadać. Prosimy zachować cierpliwość...",
-		"storageMetricsGenerationError": "Wygląda na to, że coś poszło z naszej strony nie tak. Prosimy zgłosić to do dewelopera.",
-
-		"advanced": "Zaawansowane",
-		"saveVerboseLogsDescription": "Zapisuj szczegółowe logi debugowania. Zwiększy to rozmiar logów.",
-		"saveVerboseLogs": "Zapisuj szczegółowe logi",
-
-		"about": "O aplikacji",
-		"releasedOn": "Wydano dnia {{val, datetime}}",
-		"noraWebsite": "Oficjalna strona internetowa Nory",
-		"noraDiscordServer": "Oficjalny Serwer Discord Nory",
-		"noraGithubRepo": "Repozytorium Github Nory",
-		"noraGithubIssues": "Zgłoszenia (Issues) na Githubie",
-		"noraLocalizationStatus": "Status tłumaczeń Nory",
-		"noraDescription": "Nora to elegancki odtwarzacz muzyki zbudowany przy użyciu o Electron i React.",
-		"noraInspiration": "Zainspirowane przez <Hyperlink>Oto Music for Android</Hyperlink> autorstwa Piyush Mamidwar.",
-		"otoMusicOnPlayStore": "Oto Music dla Androida w Sklepie Play",
-		"noraLicenseNotice": "Ten produkt jest licencjonowany na <Button>licencji MIT.</Button>",
-		"appLicense": "Licencja aplikacji",
-		"releaseNotes": "Informacje o wydaniu",
-		"openSourceLicenses": "Licencje Open-Source",
-		"openLogFile": "Otwórz plik logów",
-		"openDevtools": "Otwórz narzędzia deweloperskie",
-		"resyncLibrary": "Synchronizuj ponownie bibliotekę",
-		"generatePalettes": "Generuj palety kolorów",
-		"appShortcuts": "Skróty w aplikacji",
-
-		"resetApp": "Zresetuj aplikację",
-		"clearOptionalData": "Wyczyść dane opcjonalne",
-		"clearHistory": "Wyczyść historię",
-		"confirmSongHistoryDeletion": "Wyczyść historię odtwarzania",
-		"songHistoryDeletionDisclaimer": "Czy na pewno chcesz usunąć historię odtwarzania? Tej akcji nie można cofnąć.",
-		"songHistoryDeletionSuccess": "Historia odtwarzania została wyczyszczona pomyślnie.",
-		"exportAppData": "Eksportuj dane aplikacji",
-		"importAppData": "Importuj dane aplikacji",
-		"createIssueOnNoraGithubRepo": "utwórz zgłoszenie w $t(settingsPage.noraGithubRepo)",
-		"contact": "Jeśli masz uwagi na temat błędów, sugestie funkcji, i tak dalej, proszę <Hyperlink>$t(settingsPage.createIssueOnNoraGithubRepo)</Hyperlink>",
-		"emailContact": "lub skontaktuj się ze mną mailowo.",
-		"loveNora": "Stworzone z <span>❤</span> przez <Hyperlink>Sandakan Nipunajith</Hyperlink>.",
-		"sandakanGithubProfile": "Profil Github Sandakana",
-		"beautifulSriLanka": "Piękna Sri Lanka"
-	},
-
-	"artistInfoPage": {
-		"likeArtist": "Polub {{name}}",
-		"dislikeArtist": "Nie lubię {{name}}",
-		"appearsInAlbums": "Występuje w albumach",
-		"appearsInSongs": "Występuje w utworach",
-		"similarArtistsInLibrary": "Podobni wykonawcy w bibliotece",
-		"otherSimilarArtists": "Inni podobni wykonawcy",
-		"viewInLastFm": "Zobacz `{{name}}` w LastFM"
-	},
-
-	"albumInfoPage": {
-		"unavailableTracks": "Niedostępne utwory z tego albumu"
-	},
-
-	"currentQueuePage": {
-		"queue": "Kolejka odtwarzania",
-		"folderWithName": "Folder {{name}}",
-		"enableAutoScrolling": "Włącz automatyczne przewijanie",
-		"disableAutoScrolling": "Wyłącz automatyczne przewijanie",
-		"scrollToCurrentPlayingSong": "Przewiń do aktualnie odtwarzanego utworu",
-		"shuffleQueue": "Wymieszaj kolejkę",
-		"queueShuffleSuccess": "Kolejka wymieszana pomyślnie.",
-		"clearQueue": "Wyczyść kolejkę",
-		"queueCleared": "Kolejka wyczyszczona.",
-		"durationRemaining": "Pozostało {{duration}}",
-		"empty": "Kolejka jest pusta."
-	},
-
-	"lyricsEditingPage": {
-		"lyricsText": "Tekst utworu",
-		"startInSeconds": "Start (sek)",
-		"endInSeconds": "Koniec (sek)",
-		"fromTo": "Od {{start}} do {{end}}",
-		"deleteLine": "Usuń linię",
-		"addLineAbove": "Dodaj linię powyżej",
-		"addLineBelow": "Dodaj linię poniżej",
-		"addInstrumentalLineBelow": "Dodaj linię instrumentalną poniżej",
-		"editLine": "Edytuj linię",
-		"finishEditing": "Zakończ edycję",
-		"resetLyrics": "Zresetuj tekst",
-		"resetLyricsConfirm": "Czy na pewno chcesz zresetować tekst?",
-		"resetLyricsConfirmMessage": "<p>Stracisz <span>ostatnie modyfikacji tekstu utworu</span> oraz <span>dane synchronizacji startu/konca</span>, jeśli kontynuujesz tę akcję.</p> <br/> <p>Ta akcja jest nieodwracalna.</p>",
-		"incorrectSongTitle": "Nieprawidłowy utwór",
-		"incorrectSongMessage": "Aby edytować, odtwórz utwór `{{title}}`.",
-		"lyricsEditor": "Edytor tekstu",
-		"playbackSpeed": "Prędkość",
-		"playbackTime": "Czas",
-		"offsetWithCount": "Przesunięcie {{count}}",
-		"saveLyrics": "Zapisz tekst",
-		"stopAndEditLyrics": "Zatrzymaj i edytuj tekst",
-		"playLyrics": "Odtwórz tekst",
-		"configure": "Konfiguruj"
-	},
-
-	"lyricsPage": {
-		"noLyrics": "Nie znaleziono tekstu.",
-		"noLyricsDescription": "Nie znaleźliśmy tekstu dla tego utworu. Możesz dodać własny w Edytorze Tagów.",
-		"noSyncedLyrics": "Brak zsynchronizowanego tekstu.",
-		"noSyncedLyricsDescription": "Nie znaleziono czasów dla tego tekstu.",
-		"noOnlineLyrics": "Brak tekstu online.",
-		"noOfflineLyrics": "Brak tekstu offline.",
-		"noSavedLyrics": "Brak zapisanego tekstu.",
-		"onlineLyricsRefreshFailed": "Nie udało się odświeżyć tekstu online.",
-		"offlineLyricsForSong": "Tekst offline dla `{{title}}`",
-		"onlineLyricsForSong": "Tekst online dla `{{title}}`",
-		"editLyrics": "Edytuj tekst w edytorze",
-		"translateLyrics": "Przetłumacz tekst",
-		"romanizeLyrics": "Romanizuj japoński tekst utworu",
-		"convertLyricsToPinyin": "Konwertuj chiński tekst utworu na Pinyin",
-		"convertLyricsToRomaja": "Konwertuj koreański tekst na Romaja",
-		"resetLyrics": "Zresetuj tekst",
-		"showOnlineLyrics": "Pokaż tekst online",
-		"refreshOnlineLyrics": "Odśwież tekst online",
-		"showSavedLyrics": "Pokaż zapisany tekst",
-
-		"lyricsLoading": "Szukam tekstu",
-		"lyricsLoadingDescription": "Chwileczkę... Przeszukujemy sieć...",
-		"noInternet": "Brak internetu",
-		"noInternetDescription": "Brak tekstu offline. Potrzebujesz internetu, aby pobrać tekst.",
-		"lyricsProvidedBy": "Tekst dostarczony przez <Hyperlink/>",
-		"lyricsTranslatedBy": "Tekst przetłumaczony przez Tłumacz Google"
-	},
-
-	"songInfoPage": {
-		"listensCount": "{{count}} odsłuchań",
-		"listeningActivityInLastMonths": "Aktywność w ostatnich {{count}} miesiącach",
-		"similarTracksInLibrary": "Podobne utwory w Twojej bibliotece",
-		"otherSimilarTracks": "Inne podobne utwory",
-		"additionalSongInfo": "Dodatkowe informacje o utworze",
-		"allTimeListens": "Liczba odsłuchań (cały okres)",
-		"listensThisMonth": "Liczba odsłuchań (ten miesiąc)",
-		"listensThisYear": "Liczba odsłuchań (ten rok)",
-		"totalSongSkips": "Pominięcia utworu",
-		"fullSongListens": "Pełne odsłuchania",
-		"mostSoughtPosition": "Najczęściej odtwarzany moment",
-		"mostSoughtFrequency": "Liczba powtórzeń",
-		"lovedSong": "Polubiłeś(aś) ten utwór",
-		"unlovedSong": "Nie polubiłeś(aś) tego utworu",
-		"byArtists": " <By>autorstwa</By> <span>{{val, list}}</span>"
-	},
-
-	"songTagsEditingPage": {
-		"editArtwork": "Edytuj okładkę",
-		"removeArtwork": "Usuń okładkę",
-		"lyricsIncluded": "Zawiera tekst",
-		"addToMetadata": "Dodaj do metadanych",
-		"customizeMetadata": "Dostosuj metadane",
-		"songMetadataEditor": "Edytor metadanych utworu",
-		"searchMetadataOnInternet": "Szukaj metadanych w internecie",
-		"saveTags": "Zapisz tagi metadanych",
-		"updateAddedToBeSavedLater": "Aktualizacje metadanych aktualnie odtwarzanego utworu zostaną zapisane po jego zakończeniu.",
-		"pendingUpdateAvailable": "Aktualizacja tego utworu oczekuje na zapisanie.",
-		"saveTagsNotSupportedTitle": "Nieobsługiwane",
-		"saveTagsNotSupportedDescription": "<P1>Nora nie obsługuje edycji metadanych w formacie <Format/>.</P1><P2>Obecnie obsługiwany jest tylko format <SupportedFormat/>.",
-		"albumArtistNotMentioned": "Utwór jest już częścią albumu `{{title}}`, ale wykonawca `{{artists}}` nie jest oznaczony jako wykonawca albumu.",
-		"songAlbumArtistMismatch": "Wykonawcy wybranego albumu '{{albumArtists}}' nie pasują do artystów albumu '{{albumTitle}}' - '{{songAlbumArtists}}'.",
-		"searchForArtists": "Szukaj wykonawców",
-		"searchForAlbums": "Szukaj albumów",
-		"searchForGenres": "Szukaj gatunków",
-		"addNewArtist": "Dodaj nowego wykonawcę `{{name}}`",
-		"addNewAlbum": "Dodaj nowy album `{{name}}`",
-		"addNewGenre": "Dodaj nowy gatunek `{{name}}`",
-		"albumName": "Nazwa albumu",
-		"songArtists": "Wykonawcy utworu",
-		"songName": "Tytuł utworu",
-		"composer": "Kompozytor",
-		"syncedLyricsFetchFailed": "Nie udało się pobrać tekstu.",
-		"lyricsEnhancedSynced": "Tekst ma rozszerzoną synchronizację.",
-		"lyricsNotEnhancedSynced": "Tekst nie ma rozszerzonej synchronizacji.",
-		"enhancedLyricsSupported": "Obsługa rozszerzonych tekstów.",
-		"readMoreAboutLrc": "$t(common.readMoreAboutTitle, {\"title\": \"format LRC\"})",
-		"avoidUnsyncedOnSyncedLyricsTab": "Unikaj wpisywania niezsynchronizowanego tekstu w zakładce tekstu zsynchronizowanego.",
-		"avoidSyncedOnUnsyncedLyricsTab": "Unikaj wpisywania zsynchronizowanego tekstu w zakładce tekstu niezsynchronizowanego.",
-		"pendingLyricsSavesAvailable": "Oczekujące zmiany tekstu zostaną zapisane po zakończeniu odtwarzania utworu.",
-		"downloadLyrics": "Pobierz tekst",
-		"downloadSyncedLyrics": "Pobierz tekst zsynchronizowany",
-		"musixmatchNotEnabled": "Musisz włączyć teksty utworów z Musixmatch w ustawieniach, aby użyć tej funkcji."
-	},
-
-	"miniPlayer": {
-		"alwaysOnTopEnabled": "Zawsze na wierzchu: WŁ",
-		"alwaysOnTopDisabled": "Zawsze na wierzchu: WYŁ"
-	},
-
-	"time": {
-		"second_one": "sekunda",
-		"second_other": "sekund",
-		"minute_one": "minuta",
-		"minute_other": "minut",
-		"hour_one": "godzina",
-		"hour_other": "godzin",
-		"day_one": "dzień",
-		"day_other": "dni",
-		"month_one": "miesiąc",
-		"month_other": "miesięcy",
-		"year_one": "rok",
-		"year_other": "lat",
-		"secondWithCount": "{{count}} $t(time.second, {\"count\":{{count}}})",
-		"minuteWithCount": "{{count}} $t(time.minute, {\"count\":{{count}}})",
-		"hourWithCount": "{{count}} $t(time.hour, {\"count\":{{count}}})",
-		"dayWithCount": "{{count}} $t(time.day, {\"count\":{{count}}})",
-		"monthWithCount": "{{count}} $t(time.month, {\"count\":{{count}}})",
-		"yearWithCount": "{{count}} $t(time.year, {\"count\":{{count}}})"
-	},
-
-	"elapsedTime": {
-		"second_one": "{{count}} sekundę temu",
-		"second_other": "{{count}} sekund temu",
-		"minute_one": "{{count}} minutę temu",
-		"minute_other": "{{count}} minut temu",
-		"hour_one": "{{count}} godzinę temu",
-		"hour_other": "{{count}} godzin temu",
-		"day_one": "{{count}} dzień temu",
-		"day_other": "{{count}} dni temu",
-		"month_one": "{{count}} miesiąc temu",
-		"month_other": "{{count}} miesięcy temu",
-		"year_one": "{{count}} rok temu",
-		"year_other": "{{count}} lat temu"
-	},
-
-	"month": {
-		"january": "Styczeń",
-		"february": "Luty",
-		"march": "Marzec",
-		"april": "Kwiecień",
-		"may": "Maj",
-		"june": "Czerwiec",
-		"july": "Lipiec",
-		"august": "Sierpień",
-		"september": "Wrzesień",
-		"october": "Październik",
-		"november": "Listopad",
-		"december": "Grudzień"
-	},
-
-	"data": {
-		"byteWithCount_one": "{{count}} bajt",
-		"byteWithCount_other": "{{count}} bajtów"
-	},
-
-	"sideBar": {
-		"home": "Start",
-		"search": "Szukaj"
-	},
-
-	"renamePlaylistPrompt": {
-		"renamePlaylistWithName": "Zmień nazwę playlisty `{{name}}`",
-		"playlistName": "Nazwa playlisty"
-	},
-
-	"newPlaylistPrompt": {
-		"addPlaylistSuccess": "Playlista została dodana.",
-		"playlistNameEmpty": "Nazwa playlisty jest wymagana",
-		"addNewPlaylist": "Dodaj nową playlistę"
-	},
-
-	"confirmDeletePlaylistsPrompt": {
-		"playlistsDeletedWithCount": "Usunięto $t(common.playlistWithCount, {\"count\":{{count}}}).",
-		"confirmPlaylistDeleteWithCount": "Potwierdź usunięcie $t(common.playlistWithCount, {\"count\":{{count}}})",
-		"message_one": "Usunięcie tej playlisty usunie powiązania utworów w niej zawartych. Nie będziesz już mieć do niej dostępu, jeśli ją usuniesz.",
-		"message_other": "Usunięcie tych playlist usunie powiązania utworów w nich zawartych. Nie będziesz mieć już do nich dostępu, jeśli je usuniesz.",
-		"modificationNotice": "Ta akcja wpłynie na następujące pliki: "
-	},
-
-	"resetAppConfirmationPrompt": {
-		"confirmAppReset": "Potwierdź reset aplikacji",
-		"message": "Reset aplikacji usunie wszystkie dane użytkownika, w tym dane związane z utworami, ulubionymi, ustawienia itp., ale NIE usunie plików muzycznych. Ta akcja jest <span>NIEODWRACALNA</span>.",
-		"restartAfterReset": "Nora uruchomi się ponownie po resecie.",
-		"systemPlaylistsRemovalProhibited": "Nie możesz usunąć playlist takich jak Historia czy Ulubione."
-	},
-
-	"addSongsToPlaylistsPrompt": {
-		"songsAddedToPlaylists": "Dodano $t(common.songWithCount, {\"count\":{{count}}}) do $t(common.playlistWithCount, {\"count\":{{playlistCount}}})",
-		"selectPlaylistsToAdd": "Wybierz playlisty, aby dodać $t(common.songWithCount, {\"count\":{{count}}})",
-		"duplicationNotice": "Gdy dodajesz kilka utworów do playlist, utwory, które są już w wybranych playlistach zostaną pominięte."
-	},
-
-	"blacklistSongConfirmPrompt": {
-		"title": "Potwierdź wykluczenie $t(common.songWithCount, {\"count\":{{count}}}) z biblioteki",
-		"message_one": "Zamierzasz wykluczyć ten utwór z bilbioteki. Możesz go przywrócić, klikając w niego prawym przyciskiem myszy i wybierając '$t(song.deblacklist)'. Nie będzie to miało wpływu na twoje dane związane z tym utworem.",
-		"message_other": "Zamierzasz wykluczyć te utwory z bilbioteki. Możesz je przywrócić, klikając w nie prawym przyciskiem myszy i wybierając '$t(song.deblacklist)'. Nie będzie to miało wpływu na twoje dane związane z tymi utworami.",
-		"effectTitle": "Co robi wykluczenie utworu",
-		"effect1": "W bibliotece będzie widoczny jako wyszarzony i oznaczony symbolem '<span/>'.",
-		"effect2": "Nie będzie automatycznie dodawany do kolejki, ani przez <span>'$t(common.shuffleAndPlay)'</span> lub <span>'$t(common.playAll)'</span>, chyba że własnoręcznie je dodasz.",
-		"effect3": "Nadal będzie można go odtworzyć klikając podwójnie na niego lub używając <span>'$t(common.play)'</span> albo <span>'$t(common.playNext)'.</span>",
-		"songsBlacklisted": "Wykluczono i usunięto z biblioteki: $t(common.songWithCount, {\"count\":{{count}}})"
-	},
-
-	"blacklistFolderConfirmPrompt": {
-		"title": "Potwierdź wykluczenie $t(common.folderWithCount, {\"count\":{{count}}}) z biblioteki",
-		"message_one": "Zamierzasz wykluczyć ten folder. Możesz go przywrócić, klikając w niego prawym przyciskiem myszy i wybierając '$t(song.deblacklist)'. Nie będzie to miało wpływu na twoje dane związane z tym folderem.",
-		"message_other": "Zamierzasz wykluczyć te foldery. Możesz je przywrócić, klikając w nie prawym przyciskiem myszy i wybierając '$t(song.deblacklist)'. Nie będzie to miało wpływu na twoje dane związane z tymi folderami.",
-		"effectTitle": "Co robi wykluczenie folderu",
-		"effect1": "W bibliotece będzie widoczny jako wyszarzony i oznaczony symbolem '<span/>'.",
-		"effect2": "Piosenki powiązane z tym folderem zostaną również wykluczone.",
-		"effectTitle2": "Co dzieje się z piosenkami powiązanymi z wykluczonym folderem",
-		"folderBlacklisted": "Wykluczono: $t(common.folderWithCount, {\"count\":{{count}}})."
-	},
-
-	"deleteSongFromSystemConfirmPrompt": {
-		"title_one": "Usuń `{{title}}` z systemu",
-
-		"title_other": "Usuń $t(common.songWithCount, {\"count\":{{count}}}) z systemu",
-		"permanentlyDeleteFromSystem": "Permanentnie usuń z systemu",
-		"message_one": "Stracisz ten utwór ze swojego systemu i możesz nie być w stanie go później odzyskać, jeśli wybierzesz opcję systemu '$t(deleteSongFromSystemConfirmPrompt.permanentlyDeleteFromSystem)'.",
-		"message_other": "Stracisz te utwory ze swojego systemu i możesz nie być w stanie ich później odzyskać, jeśli wybierzesz opcję systemu '$t(deleteSongFromSystemConfirmPrompt.permanentlyDeleteFromSystem)'.",
-		"modificationNotice": "Ta akcja dotyczy następujących plików:",
-		"deleteSong": "Usuń utwór",
-		"songPermanentlyDeleted": "Usunięto $t(common.songWithCount, {\"count\":{{count}}}) z systemu.",
-		"songMovedToBin": "Przeniesiono $t(common.songWithCount, {\"count\":{{count}}}) do kosza."
-	},
-
-	"addMusicFoldersPrompt": {
-		"title": "Wybierz foldery do dodania",
-		"emptyMessage1": "Wygląda na to, że nie wybrałeś(aś) żadnych folderów.",
-		"emptyMessage2": "Wybierz foldery z Twojego systemu. Pojawią się one tutaj, aby można było je dalej dostosować.",
-		"chooseFolders": "Wybierz foldery",
-		"addSelectedFolders": "Dodaj wybrane foldery",
-		"noFoldersSelected": "Nie wybrano folderów. (Muszą mieć jeden folder nadrzędny)"
-	},
-
-	"removeFolderConfirmationPrompt": {
-		"title": "Potwierdź usunięcie folderu `{{folderName}}`",
-		"message": "Jesteś pewny(a), że chcesz usunąć ten folder z biblioteki? Usunie to wszystkie dane związane z tym folderem, włącznie z danymi o utworach z biblioteki. Pliki na Twoim systemie pozostaną nienaruszone.",
-		"removeFolder": "Usuń folder"
-	},
-
-	"lyricsEditorHelpPrompt": {
-		"title": "Jak używać edytora tekstu Nory",
-		"subTitle1": "Jak zacząć korzystać z edytora?",
-		"subTitle1Message": " <ol><li>Odtwórz utwór, którego tekst próbujesz edytować. (Jeśli nie będziesz na właściwym utworze, aplikacja zablokuje dodawanie błędnych metadanych do linii tekstu.)</li><li>Kliknij w obszar strony, aby ustawić na niej fokus. (Fokus na stronie jest wymagany, aby skróty klawiszowe specyficzne dla tej strony działały poprawnie.)</li><li>Zacznij odtwarzać utwór od początku. Jeśli chcesz mieć większą kontrolę nad odtwarzaniem, ustaw powtarzanie bieżącego utworu.</li><li>Gdy w utworze padają słowa z danej linii tekstu, naciśnij <ShortcutButton>$t(appShortcutsPrompt.enterKey)</ShortcutButton>, aby podświetlić następną linię i dodać znacznik czasu rozpoczęcia.</li><li>Kontynuuj aż do ostatniej linijki tekstu.</li></ol>",
-		"subTitle2": "Jakie skróty klawiszowe mogę używać w edytorze tekstu?",
-		"subTitle2Message": "Przejdź do <Button>Podpowiedzi skrótów</Button>, aby zobaczyć odpowiednie skróty, których można używać w edytorze tekstu.",
-		"subTitle3": "Czy pominąłem linię?",
-		"subTitle3Message": "<ol><li>Zatrzymaj utwór.</li><li>Znajdź odpowiednią linię tekstu.</li><li>Kliknij przycisk <ShortcutButton>Edytuj</ShortcutButton> pod tą linią i wprowadź niezbędne zmiany.</li><li>Po wprowadzeniu zmian kliknij <ShortcutButton>$t(lyricsEditingPage.finishEditing)</ShortcutButton>, aby zakończyć edycję.</li></ol>",
-		"subTitle4": "Dodałem złe dane do złej linii?"
-	},
-
-	"lyricsEditorSavePrompt": {
-		"lyricsUpdateSuccess": "Tekst zaktualizowany pomyślnie.",
-		"saveEditedLyrics": "Zapisz edytowany tekst",
-		"copyLyrics": "Kopiuj tekst",
-		"saveLyricsToSong": "Zapisz tekst do utworu",
-		"saveLyricsNotSupported": "Nora aktualnie nie wspiera zapisu tekstu do utworów w formacie '{{format}}'.",
-		"saveLyricsFormatInfo": "* Teksty są zapisywane w formacie <Hyperlink>LRC</Hyperlink>.",
-		"readAboutLrcFormat": "Przezytaj więcej o formacie LRC"
-	},
-
-	"lyricsEditorSettingsPrompt": {
-		"lyricsEditorSettings": "Ustawienia edytora tekstu",
-		"editNextAndCurrentStartAndEndTagsAutomaticallyDescription": "Automatycznie zmieniaj znacznik czasu rozpoczęcia następnej linii tekstu, gdy edytujesz znacznik zakończenia bieżącej linii (i odwrotnie).",
-		"editNextAndCurrentStartAndEndTagsAutomatically": "Automatycznie edytuj znacznik startu następnej linii wraz z końcem bieżącej (i odwrotnie).",
-		"lyricOffsetInputDescription": "Wybierz ujemne lub dodatnie przesunięcie, które zostanie dodane do linii tekstu podczas ich automatycznej edycji.",
-		"lyricOffsetInput": "Przesunięcie (+ lub -)"
-	},
-
-	"pageFocusPrompt": { "pageNotFocused": "Brak fokusu na stronie." },
-
-	"releaseNotesPrompt": {
-		"latestVersion": "Masz najnowszą wersję.",
-		"oldVersion": "<br/><span>Nie masz najnowszej wersji.</span> <Hyperlink>Aktualizuj teraz</Hyperlink>",
-		"outdatedChangelogNotice": "Możesz oglądać przestarzały dziennik zmian.",
-		"versionCheckError": "<br/><span>Nie udało się sprawdzić aktualizacji. Coś jest nie tak po naszej stronie.<div>$t(releaseNotesPrompt.outdatedChangelogNotice)</div></span>",
-		"versionCheckNetworkError": "<br/><span> Nie udało się sprawdzić aktualizacji. Sprawdź swoje połączenie z internetem i spróbuj ponownie.<div>$t(releaseNotesPrompt.outdatedChangelogNotice)</div></span>",
-		"noraReleases": "Wydania Nory",
-		"changelog": "Dziennik zmian",
-		"doNotRemindThisVersionUpdate": "Nie przypominaj mi więcej o tej wersji.",
-		"current": "Obecna",
-		"latest": "Najnowsza",
-		"newFeaturesAndUpdates": "Nowości i aktualizacje",
-		"fixesAndImprovements": "Poprawki i ulepszenia",
-		"issuesAndBugs": "Znane problemy i bugi",
-		"developerUpdates": "Wieści od dewelopera"
-	},
-
-	"appShortcutsPrompt": {
-		"inAppShortcuts": "Skróty w aplikacji",
-
-		"mediaPlayback": "Odtwarzanie",
-		"playPause": "Odtwórz / Pauza",
-		"toggleMute": "Przełącz wyciszenie",
-		"nextSong": "Następny utwór",
-		"prevSong": "Poprzedni utwór",
-		"tenSecondsForward": "10 sekund do przodu",
-		"tenSecondsBackward": "10 sekund do tyłu",
-		"upVolume": "zwiększ głośność",
-		"downVolume": "zmniejsz głośność",
-		"toggleShuffle": "Przełącz losowanie kolejki",
-		"toggleRepeat": "Przełącz powtarzanie kolejki",
-		"toggleFavorite": "Przełącz ulubione",
-		"upPlaybackRate": "Zwiększ prędkość odtwarzania o 0.05x",
-		"downPlaybackRate": "Zmniejsz prędkość odtwarzania o 0.05x",
-		"resetPlaybackRate": "Zresetuj prędkość odtwarzania do 1x",
-
-		"navigation": "Nawigacja",
-		"goHome": "Strona główna",
-		"goBack": "Wstecz",
-		"goForward": "Dalej",
-		"openMiniPlayer": "Otwórz Mini Odtwarzacz",
-		"goToLyrics": "Idź do tekstu utworu",
-		"goToQueue": "Idź do bieżącej kolejki",
-		"goToSearch": "Idź do szukania",
-
-		"selections": "Zaznaczanie",
-		"selectMultipleItems": "Zaznacz wiele",
-
-		"lyrics": "Tekst",
-		"playNextLyricsLine": "Odtwórz następną linię tekstu",
-		"playPrevLyricsLine": "Odtwórz poprzednią linię tekstu",
-
-		"lyricsEditor": "Edytor tekstu",
-		"selectNextLyricsLine": "Zaznacz następną linię tekstu",
-		"selectPrevLyricsLine": "Zaznacz poprzednią linię tekstu",
-		"selectCustomLyricsLine": "Zaznacz własną linię tektsu",
-
-		"otherShortcuts": "Inne skróty",
-		"toggleTheme": "Przełącz motyw aplikacji",
-		"toggleMiniPlayerAlwaysOnTop": "Przełącz bycie Mini Odtwarzacza zawsze na wierzchu",
-		"reload": "Załaduj od nowa",
-		"openDevtools": "Otwórz DevTools",
-		"openAppShortcutsPrompt": "Otwórz podpowiedzi skrótów aplikacji",
-
-		"enterKey": "Enter",
-		"spaceKey": "Spacja",
-		"ctrlKey": "Ctrl",
-		"shiftKey": "Shift",
-		"altKey": "Alt",
-		"homeKey": "Home",
-		"rightArrowKey": "Strzałka w prawo",
-		"leftArrowKey": "Strzałka w lewo",
-		"upArrowKey": "Strzałka w górę",
-		"downArrowKey": "Strzałka w dół",
-
-		"mouseClick": "Kliknięcie myszy",
-		"doubleClick": "Podwójne kliknięcie myszy"
-	},
-
-	"clearLocalStoragePrompt": {
-		"title": "Potwierdź wyczyszczenie lokalnych danych na dysku",
-		"description": "Ten proces usunie wszelkie uszkodzone dane pamięci lokalnej w aplikacji Nora i przywróci ją do ustawień domyślnych.",
-		"effect": "<p>Wykonanie tej akcji wpłynie na następujące dane: </p><ul><li>Większość ustawień preferencji w aplikacji Nora</li><li>Ustawienia odtwarzania, takie jak obecnie grany utwór, głośność itp.</li><li>Dane bieżącej kolejki</li><li>Dane ignorowanych sugestii, takich jak artyści gościnni, oddzielni wykonawcy i duplikaty</li><li>Dane sortowania stron</li><li>Dane korektora graficznego</li><li>Ustawienia edytora tekstu</li></ul>",
-		"restartNotice": "Po zakończeniu procesu aplikacja Nora uruchomi się ponownie."
-	},
-
-	"musixmatchDisclaimerPrompt": {
-		"title": "Zastrzeżenie – teksty Musixmatch",
-		"message": "<li>Teksty Musixmatch są dodane do tego oprogramowania jako funkcja testowa i mogą zostać usunięte w dowolnym momencie.</li><li>Nora nie jest w żaden sposób powiązana z Musixmatch Lyrics ani żadną z jego firm stowarzyszonych lub spółek zależnych, nie jest też przez nie autoryzowana, utrzymywana, sponsorowana ani popierana.</li><li>Opiekunowie tej aplikacji apelują do użytkowników o osobistą odpowiedzialność i korzystanie z tej funkcji w uczciwy sposób, zgodnie z jej przeznaczeniem oraz z poszanowaniem praw autorskich stosowanych przez Musixmatch Lyrics.</li>",
-		"implementationNotice": "Implementacja na podstawie <Hyperlink/> autorstwa Fashni.",
-		"hyperlinkTitle": "Repozytorium GitHub MxLRC",
-		"contactAboutComplaints": "Jeśli masz jakiekolwiek skargi/zażalenia, możesz skontaktować się ze mną przez serwer Discord Nora albo przez mój <Hyperlink>email</Hyperlink>."
-	},
-
-	"musixmatchSettingsPrompt": {
-		"title": "Ustawienia Musixmatch",
-		"message": "<li>Musixmatch wymaga tokenu użytkownika do poprawnego działania.</li><li>Musixmatch może czasem nie wyświetlać tekstów z powodu długotrwałego korzystania z usługi na tym samym tokenie.</li><li>Skorzystaj z poradnika na <Hyperlink>Wiki Spicetify</Hyperlink>, aby uzyskać nowy token Musixmatch.</li>",
-		"showToken": "Pokaż token",
-		"hideToken": "Ukryj token",
-		"updateToken": "Zaktualizuj token",
-		"tokenUpdateSuccess": "Pomyślnie zaktualizowano token.",
-		"tokenUpdateFailed": "Nie udało się zaktualizować tokenu.",
-		"tokenMissingCharacters": "TOKEN powinien być ciągiem 54 znaków. (Wymagane jeszcze: {{count}}).",
-		"tokenIncorrectCharacters": "TOKEN powinien zawierać tylko znaki alfanumeryczne.",
-		"savedTokenAvailableMessage": "<Title><span/> Zapisany token jest dostępny.</Title><p> W aplikacji Nora dostępny jest już ważny token Musixmatch zapisany przez użytkownika.</p> <p> Musisz zmieniać token tylko wtedy, gdy usługa nie działa poprawnie.</p>"
-	},
-
-	"customizeSelectedMetadataPrompt": {
-		"selected": "Wybrano",
-		"select": "Wybierz",
-		"title": "Dostosuj pobrane metadane dla `{{title}}`",
-		"selectArtwork": "Wybierz okładkę",
-		"noArtworksFound": "Brak okładek",
-		"customizeOtherMetadata": "Inne metadane",
-		"syncedLyricsAvailable": "Dostępny tekst zsynchronizowany",
-		"unsyncedLyricsAvailable": "Dostępny tekst",
-		"addOnlySelected": "Dodaj wybrane",
-		"addAll": "Dodaj wszystkie"
-	},
-
-	"resetTagsToDefaultPrompt": {
-		"changed": "Zmieniono",
-		"title": "Potwierdź resetowanie danych utworu do domyślnych",
-		"description": "Jesteś pewny(a), że chcesz zresetować dane utworu? Stracisz dane, które edytowałeś(aś) na tym ekranie.",
-		"resetToDefault": "Przywróć domyślne"
-	},
-
-	"songMetadataResultSelectPrompt": {
-		"title": "Wyniki dla <span/>"
-	},
-
-	"errorPrompt": {
-		"title": "Wystąpił błąd",
-		"sendErrorInfo": "Prześlij nam <Hyperlink1>opinię</Hyperlink1>, aby ulepszyć aplikację, lub <Hyperlink2>zgłoś problem</Hyperlink2> na GitHubie."
-	},
-
-	"openLinkConfirmPrompt": {
-		"description": "Próbujesz otworzyć link, który przekieruje Cię do <span/>.<br/> Ten link zostanie otwarty w Twojej domyślnej przeglądarce.",
-		"doNotVerifyLink": "Nie weryfikuj przy próbie otwarcia linku.",
-		"openLink": "Otwórz link"
-	},
-
-	"songUnplayableErrorPrompt": {
-		"title": "Nie można odtworzyć utworu",
-		"description": "Wygląda na to, że nie możemy odtworzyć tego utworu. Sprawdź, czy wybrany utwór jest dostępny w systemie i czy aplikacja ma do niego dostęp.",
-		"formatNotSupportedTitle": "Czy ten utwór jest obsługiwany w Norze?",
-		"formatNotSupportedDescription": "Ten format pliku audio może nie być obsługiwany przez twoją aktualną konfigurację systemu lub przeglądarki. Sprawdź listę obsługiwanych formatów poniżej.",
-		"flacNotSupportedDescription": "Pliki FLAC nie są obsługiwane w Norze ze względu na ograniczenia kodeków w silniku przeglądarki. Możesz jednak konwertować swoje pliki FLAC do formatu MP3, OGG lub WAV i będą się doskonale odtwarzać w Norze.",
-		"supportedFormatsLabel": "Obsługiwane formaty audio:",
-		"flacConversionHint": "💡 Spróbuj konwertować swoje pliki FLAC do MP3 (zalecane), OGG lub WAV za pomocą bezpłatnych narzędzi takich jak FFmpeg lub Audacity."
-	},
-
-	"unsupportedFileMessagePrompt": {
-		"title": "Nieobsługiwany plik audio",
-		"description": "Próbujesz otworzyć plik z rozszerzeniem <span/>, które nie jest obsługiwane przez tę aplikację.<br/> Obecnie obsługujemy tylko następujące formaty audio. <div/>"
-	},
-
-	"duplicateArtistsSuggestion": {
-		"message": "<div><p>Czy <span/> to ten sam wykonawca?</p><p>Jeśli tak, możesz połączyć ich treści w jednego wykonawcę lub zignorować tę sugestię.</p></div>",
-		"linkToArtist": "Połącz z {{name}}"
-	},
-
-	"separateArtistsSuggestion": {
-		"message": "<div><p>Czy <span/> to {{count}} osobnych artystów?</p><p>Jeśli tak, możesz ich zorganizować, zaznaczając jako osobnych wykonawców, lub zignorować tę sugestię.</p></div>",
-		"separateAsArtists": "Rozdziel jako {{count}} artystów"
-	},
-
-	"featArtistsSuggestion": {
-		"message_one": "<p>Czy <span/> to artysta gościnny w tym utworze?</p><p>Jeśli tak, możesz dodać go jako wykonawcę tego utworu lub zignorować tę sugestię.</p>",
-		"message_other": "<p>Czy <span/> to {{count}} artystów gościnnych w tym utworze?</p><p>Jeśli tak, możesz dodać ich jako wykonawców tego utworu lub zignorować tę sugestię.</p>",
-		"featArtistsTitleReset": "Usuń informacje o artystach gościnnych z tytułu utworu po dodaniu ich do listy wykonawców.",
-		"addArtistsToSong": "Dodaj $t(common.artistWithCount, {\"count\":{{count}}}) do utworu",
-		"editInMetadataEditingPage": "Edytuj na stronie edycji metadanych",
-		"modificationNotice": "Pamiętaj, że dodanie artystów gościnnych do utworu zaktualizuje zarówno dane w bibliotece, jak i metadane pliku."
-	},
-
-	"biography": {
-		"readMore": "Czytaj więcej...",
-		"readMoreInLastFm": "Czytaj więcej na LastFM",
-		"aboutName": "O <span/>",
-		"goToTagInLastFm": "Przejdź do tagu {{name}} na LastFM"
-	},
-
-	"notifications": {
-		"clearAll": "Wyczyść wszystko",
-		"playingNext": "`{{title}}` będzie grane jako następne.",
-		"songBlacklisted": "`{{title}}` jest wykluczony.",
-		"playingNextSongsWithCount": "$t(common.songWithCount, {\"count\":{{count}}}) będzie grane jako następne.",
-		"addedToQueue": "Dodano $t(common.songWithCount, {\"count\":{{count}}}) do kolejki",
-		"suggestionIgnored": "Sugestia zignorowana.",
-		"songRestoreSuccess": "Utwór przywrócony pomyślnie.",
-		"songDataUpdateFailed": "Błąd aktualizacji danych utworu.",
-		"noSongDataEdits": "Nie zmieniłeś(aś) żadnych danych utworu.",
-		"selectASongToPlay": "Wybierz utwór do odtwarzania",
-		"alreadyInPage": "Jesteś już na tej stronie.",
-		"playbackRateChanged": "Zmieniono prędkość odtwarzania na {{val}}x",
-		"playbackRateReset": "Zresetowano prędkosć odtwarzania do 1x",
-		"playbackPausedDueToSongDeletion": "Odtwarzanie zostało zatrzymane, ponieważ aktualny utwór został usunięty.",
-		"languageChanged": "Zmieniono pomyślnie język aplikacji."
-	},
-
-	"backend": {
-		"RESYNC_SUCCESSFUL": "Ponowna synchronizacja biblioteki ukończona pomyślnie.",
-		"RESET_SUCCESSFUL": "Zresetowano aplikację, trwa ponowne uruchamianie.",
-		"RESET_FAILED": "Reset aplikacji nie podiódł się. Ponowne ładowanie aplikacji.",
-		"APP_THEME_CHANGE": "Motyw systemowy zmieniony na {{theme}}",
-		"SONG_REMOVE_PROCESS_UPDATE": "Usunięto {{value}} z {{total}} utworów.",
-		"OPEN_SONG_IN_EXPLORER_FAILED": "Otwarcie pliku utworu w eksploratorze nie powiodło się, ponieważ nie znaleziono utworu w bibliotece.",
-		"PENDING_METADATA_UPDATES_SAVED": "Pomyślnie zapisano oczekujące aktualizacje metadanych dla `{{title}}`.",
-		"METADATA_UPDATE_FAILED": "Aktualizacja metadanych nie powiodła się. {{message}}",
-		"SONG_EXT_NOT_SUPPORTED_FOR_LYRICS_SAVES": "Nie można zapisać tekstu, ponieważ rozszerzenie bieżącego utworu ({{ext}}) nie obsługuje modyfikacji metadanych.",
-		"LASTFM_LOGIN_SUCCESS": "Pomyślnie zalogowano do LastFM.",
-		"AUDIO_PARSING_PROCESS_UPDATE": "Przetworzono {{value}} z {{total}} utworów.",
-		"SONG_PALETTE_GENERATING_PROCESS_UPDATE": "Generowanie palet kolorów dla {{value}} z {{total}} utworów.",
-		"GENRE_PALETTE_GENERATING_PROCESS_UPDATE": "Generowanie palet kolorów dla {{value}} z {{total}} gatunków.",
-		"LYRICS_FIND_FAILED": "Nie znaleziono tekstu dla `{{title}}`",
-		"LYRICS_TRANSLATION_SUCCESS": "Tekst przetłumaczony pomyślnie",
-		"LYRICS_CONVERT_SUCCESS": "Tekst przekonwertowany pomyślnie",
-		"RESET_CONVERTED_LYRICS_SUCCESS": "Pomyślnie zresetowano tekst",
-		"LYRICS_TRANSLATION_FAILED": "Nie udało się przetłumaczyć tekstu",
-		"LYRICS_TRANSLATION_TO_SAME_SOURCE_LANGUAGE": "Zażądano tłumaczenia tekstu na ten sam język źródłowy '{{language}}'",
-		"LYRICS_CONVERT_FAILED": "Nie udało się przekonwertować tekstu",
-		"RESET_CONVERTED_LYRICS_FAILED": "Nie udało się zresetować tekstu",
-		"MUSIC_FOLDER_DELETED": "Folder `{{name}}` został usunięty z systemu. $t(common.songWithCount, {\"count\":{{count}}}) powiązane z tym folderem zostaną usunięte z biblioteki.",
-		"EMPTY_MUSIC_FOLDER_DELETED": "Folder `{{name}}` został usunięty z systemu. Nie znaleziono utworów powiązanych z tym folderem. Biblioteka pozostanie bez zmian.",
-		"WHITELISTING_FOLDER_FAILED_DUE_TO_BLACKLISTED_PARENT_FOLDER": "Nie można oznaczyć folderu `{{folderName}}` jako dopuszczony, ponieważ jego folder nadrzędny '{{parentFolderName}}' jest wykluczony. Oznacz folder nadrzędny jako dopuszczony, aby odblokować ten folder.",
-		"WHITELISTING_SONG_FAILED_DUE_TO_BLACKLISTED_DIRECTORY": "Nie można oznaczyć utworu '{{songName}}' jako dopuszczony, ponieważ jego katalog '{{directoryName}}' jest wykluczony. Oznacz ten katalog jako dopuszczony, aby odblokować ten utwór.",
-		"SONG_WHITELISTED": "$t(common.songWithCount, {\"count\":{{count}}}) usunięto z wykluczonych.",
-		"ARTWORK_SAVED": "Zapisano okładkę w wybranej lokalizacji.",
-		"DESTINATION_NOT_SELECTED": "Nie wybrano miejsca zapisu.",
-		"ARTWORK_SAVE_FAILED": "Nie udało się zapisać okładki.",
-		"PLAYBACK_FROM_UNKNOWN_SOURCE": "Odtwarzasz utwór spoza Twojej biblioteki.",
-		"ARTIST_DISLIKE": "Artysta `{{name}}` został usunięty z ulubionych.",
-		"ARTIST_LIKE": "Artysta `{{name}}` został dodany do ulubionych.",
-		"SONG_DISLIKE": "Utwór `{{name}}` został usunięty z ulubionych.",
-		"SONG_LIKE": "Utwór `{{name}}` został dodany do ulubionych.",
-		"SONG_DELETED": "Utwór `{{name}}` został usunięty z systemu.",
-		"FOLDER_PARSED_FOR_DIRECTORIES": "Znaleziono $t(folder.directoryCount, {\"count\":{{count}}}) w $t(folder.selectedFolderCount, {\"count\":{{folderCount}}}).",
-		"NO_MORE_SONG_PALETTES": "Brak kolejnych palet utworów do wygenerowania.",
-		"NO_MORE_GENRE_PALETTES": "Brak kolejnych palet gatunków do wygenerowania.",
-		"PARSE_FAILED": "Błąd `{{name}}` podczas próby dodania utworu do biblioteki. Przejdź do ustawień, aby ponownie zsynchronizować bibliotekę.",
-		"PARSE_SUCCESSFUL": "Utwór `{{name}}` dodano do biblioteki.",
-		"LYRICS_SAVE_QUEUED": "Tekst dla `{{title}}` zostanie zapisany automatycznie.",
-		"LYRICS_SAVED_IN_LRC_FILE": "Tekst dla tego utworu z rozszerzeniem '{{ext}}' zostanie zapisany w pliku LRC.",
-		"PENDING_LYRICS_SAVED": "Pomyślnie zapisano oczekujące teksty dla `{{title}}`.",
-		"ADDED_SONGS_TO_PLAYLIST": "Pomyślnie dodano $t(common.songWithCount, {\"count\":{{count}}}) do `{{name}}`.",
-		"APPDATA_IMPORT_STARTED": "Rozpoczęto importowanie danych aplikacji. Proszę czekać...",
-		"APPDATA_IMPORT_SUCCESS": "Pomyślnie zaimportowano dane aplikacji.",
-		"APPDATA_IMPORT_SUCCESS_WITH_PENDING_RESTART": "$t(backend.APPDATA_IMPORT_SUCCESS) Aplikacja zostanie zrestartowana za 5 sekund.",
-		"APPDATA_IMPORT_FAILED": "Nie udało się zaimportować danych aplikacji.",
-		"APPDATA_IMPORT_FAILED_DUE_TO_MISSING_FILES": "$t(backend.APPDATA_IMPORT_FAILED) W wybranym folderze brakuje wymaganych plików.",
-		"APPDATA_EXPORT_STARTED": "Rozpoczęto eksportowanie danych aplikacji. Proszę czekać...",
-		"APPDATA_EXPORT_SUCCESS": "Pomyślnie wyeksportowano dane aplikacji.",
-		"APPDATA_EXPORT_FAILED": "Wystąpił błąd podczas eksportowania danych aplikacji.",
-		"PLAYLIST_EXPORT_SUCCESS": "Pomyślnie wyeksportowano playlistę `{{name}}`.",
-		"PLAYLIST_EXPORT_FAILED": "Wystąpił błąd podczas eksportowania playlisty `{{name}}`.",
-		"PLAYLIST_IMPORT_SUCCESS": "Pomyślnie zaimportowano playlistę `{{name}}`.",
-		"PLAYLIST_IMPORT_FAILED": "Nie udało się zaimportować playlisty.",
-		"PLAYLIST_IMPORT_FAILED_DUE_TO_SONGS_OUTSIDE_LIBRARY": "Podczas importu playlisty znaleziono $t(common.songWithCount, {\"count\":{{count}}}) spoza biblioteki, co nie jest obsługiwane.",
-		"PLAYLIST_IMPORT_FAILED_DUE_TO_INVALID_FILE_DATA": "Nie udało się zaimportować playlisty, ponieważ wybrano plik z nieprawidłowymi danymi.",
-		"PLAYLIST_IMPORT_FAILED_DUE_TO_INVALID_FILE_EXTENSION": "Import playlisty nie powiódł się, ponieważ wybrany plik nie miał rozszerzenia '.m3u8'.",
-		"PLAYLIST_IMPORT_TO_EXISTING_PLAYLIST": "Zaimportowano $t(common.songWithCount, {\"count\":{{count}}}) do istniejącej playlisty `{{name}}`.",
-		"PLAYLIST_IMPORT_TO_EXISTING_PLAYLIST_FAILED": "Wystąpił błąd podczas importowania utworów do istniejącej playlisty.",
-		"PLAYLIST_CREATION_FAILED": "Nie udało się utworzyć playlisty.",
-		"PLAYLIST_RENAME_SUCCESS": "Zmieniono nazwę playlisty pomyślnie.",
-		"PLAYLIST_NOT_FOUND": "Nie znaleziono playlisty.",
-		"SONG_REPARSE_SUCCESS": "Pomyślnie przetworzono ponownie `{{title}}`.",
-		"SONG_REPARSE_FAILED": "Wystąpił błąd podczas ponownego przetwarzania utworu."
-	},
-
-	"discordrpc": {
-		"noraOnGitHub": "Nora na GitHubie",
-		"untitledSong": "Utwór bez tytułu",
-		"unknownArtist": "nieznany wykonawca",
-		"playingASong": "Słucha utworu"
-	}
+  "common": {
+    "song_one": "utwór",
+    "song_other": "Utwory",
+    "playlist_one": "playlista",
+    "playlist_other": "Playlisty",
+    "artist_one": "wykonawca",
+    "artist_other": "Wykonawcy",
+    "album_one": "album",
+    "album_other": "Albumy",
+    "genre_one": "gatunek",
+    "genre_other": "Gatunki",
+    "folder_one": "folder",
+    "folder_other": "Foldery",
+    "songWithCount_one": "{{count}} utwór",
+    "songWithCount_other": "{{count}} utworów",
+    "playlistWithCount_one": "{{count}} playlista",
+    "playlistWithCount_other": "{{count}} playlist",
+    "artistWithCount_one": "{{count}} wykonawca",
+    "artistWithCount_other": "{{count}} wykonawców",
+    "albumWithCount_one": "{{count}} album",
+    "albumWithCount_other": "{{count}} albumów",
+    "genreWithCount_one": "{{count}} gatunek",
+    "genreWithCount_other": "{{count}} gatunków",
+    "folderWithCount_one": "{{count}} folder",
+    "folderWithCount_other": "{{count}} folderów",
+    "subFolderWithCount_one": "{{count}} podfolder",
+    "subFolderWithCount_other": "{{count}} podfolderów",
+
+    "selectionWithCount_one": "Wybrano {{count}}",
+    "selectionWithCount_other": "Wybrano {{count}}",
+
+    "shownWithCount": "Wyświetlono {{count}}",
+
+    "unknownTitle": "Nieznany tytuł",
+    "unknownArtist": "Nieznany wykonawca",
+    "unknownAlbum": "Nieznany album",
+    "unknownGenre": "Nieznany gatunek",
+    "unknownFolder": "Nieznany folder",
+    "unknownLyricsProvider": "Nieznany dostawca tekstu",
+
+    "songTitle": "Tytuł utworu",
+    "duration": "Czas trwania",
+    "albumArtists": "Wykonawcy albumu",
+    "albumTrackNo": "Numer utworu na albumie",
+    "releasedYear": "Rok wydania",
+    "songAddedOn": "Data dodania utworu",
+    "lastModifiedOn": "Ostatnia modyfikacja",
+    "sampleRate": "Częstotliwość próbkowania",
+    "bitRate": "Bitrate",
+    "noOfAudioChannels": "Liczba kanałów audio",
+    "channelWithCount_one": "{{count}} kanał (Mono)",
+    "channelWithCount_other": "{{count}} kanałów (Stereo)",
+    "songLocation": "Lokalizacja pliku",
+    "lyrics": "Tekst utworu",
+    "syncedLyrics": "Tekst zsynchronizowany",
+    "unsyncedLyrics": "Tekst niezsynchronizowany",
+
+    "play": "Odtwórz",
+    "playNext": "Odtwórz jako następne",
+    "playNextAll": "Dodaj wszystko jako następne",
+    "shuffleAndPlay": "Losuj i odtwarzaj",
+    "shuffleAndPlayAll": "Losuj i odtwarzaj wszystko",
+    "playAll": "Odtwórz wszystko",
+    "addToQueue": "Dodaj do kolejki",
+    "removeFromQueue": "Usuń z kolejki",
+    "addSongsToQueue": "Dodaj utwory do kolejki",
+    "createAQueue": "Utwórz kolejkę",
+    "info": "Informacje",
+    "select": "Wybierz",
+    "unselect": "Odznacz",
+    "selectAll": "Zaznacz wszystko",
+    "unselectAll": "Odznacz wszystko",
+    "showAll": "Pokaż wszystko",
+    "cancel": "Anuluj",
+    "search": "Szukaj",
+    "help": "Pomoc",
+    "copy": "Kopiuj",
+
+    "sortBy": "Sortuj według",
+    "filterBy": "Filtruj według",
+    "moreOptions": "Więcej opcji",
+    "title": "Tytuł",
+    "suggestion": "Sugestia",
+    "hideSuggestion": "Ukryj sugestię",
+    "showSuggestion": "Pokaż sugestię",
+    "and": "i",
+    "ignore": "Ignoruj",
+    "goBack": "Wstecz",
+    "saveArtwork": "Zapisz okładkę",
+    "readMoreAboutTitle": "Czytaj więcej o `{{title}}`",
+    "doNotShowThisMessageAgain": "Nie pokazuj tego ponownie.",
+    "artistConflictResolved": "Konflikt wykonawców rozwiązany pomyślnie.",
+    "featArtistSuggestionResolved": "Sugestia dotycząca gościnnie występujących artystów rozwiązana pomyślnie.",
+    "hasInternet": "Jesteś połączony(a) z internetem.",
+    "noInternet": "Nie jesteś połączony(a) z internetem.",
+    "newUpdateAvailable": "Dostępna jest nowa aktualizacja aplikacji.",
+    "checkingForUpdates": "Sprawdzanie aktualizacji...",
+    "updateCheckError": "Wystąpił błąd podczas sprawdzania aktualizacji.",
+    "updateCheckErrorNoInternet": "$t(common.updateCheckError) $t(common.noInternet)",
+    "optionDisabled": "Ta opcja jest wyłączona.",
+    "somethingWentWrong": "Coś poszło nie tak.",
+    "details": "Szczegóły",
+    "restartApp": "Uruchom ponownie aplikację",
+    "ok": "OK",
+    "loading": "Wczytywanie"
+  },
+
+  "titleBar": {
+    "changeTheme": "Zmień motyw",
+    "goBack": "Wstecz (Alt + Strzałka w lewo)",
+    "goHome": "Strona główna (Alt + Home)",
+    "goForward": "Dalej (Alt + Strzałka w prawo)",
+
+    "minimize": "Minimalizuj",
+    "maximize": "Maksymalizuj",
+    "close": "Zamknij"
+  },
+
+  "player": {
+    "goToMainPlayer": "Przejdź do głównego odtwarzacza (Ctrl + N)",
+    "openInMiniPlayer": "Otwórz w Mini Odtwarzaczu (Ctrl + N)",
+    "openInFullScreen": "Otwórz na pełnym ekranie",
+    "likeDislike": "Oznacz jako lubiane albo nielubiane (Ctrl + H)",
+    "likeDislikeDisabled": "Oznaczanie jako lubiane albo nielubiane jest wyłączone, ponieważ odtwarzany utwór pochodzi z nieznanego źródła i tego nie wspiera.",
+    "prevSong": "Poprzedni utwór (Ctrl + Strzałka w lewo)",
+    "playPause": "Graj/Pauza (Spacja)",
+    "nextSong": "Następny utwór (Ctrl + Strzałka w prawo)",
+    "lyrics": "Tekst utworu (Ctrl + L)",
+    "shuffle": "Losuj (Ctrl + S)",
+    "repeat": "Powtarzaj (Ctrl + T)",
+    "muteUnmute": "Wycisz/Odcisz (Ctrl + M)",
+    "currentQueue": "Bieżąca kolejka (Ctrl + Q)",
+    "adjustPlaybackSpeed": "Dostosuj prędkość odtwarzania",
+    "showCurrentQueue": "Pokaż bieżącą kolejkę",
+    "showMiniPlayer": "Pokaż Mini Odtwarzacz",
+    "otherSettings": "Inne ustawienia",
+    "upNext": "NASTĘPNE: ",
+    "closeUpNext": "Zamknij 'NASTĘPNE'",
+    "by": "autorstwa",
+
+    "errorTitle": "Wystąpił błąd w odtwarzaczu.",
+    "errorMessage": "$t(player.errorTitle)<br /> Może to być wynik próby odtworzenia uszkodzonego utworu. <details/>",
+    "noErrorMessage": "Nie wygenerowano komunikatu o błędzie"
+  },
+
+  "sortTypes": {
+    "aToZ": "A do Z",
+    "zToA": "Z do A",
+    "dateAddedAscending": "Najstarsze",
+    "dateAddedDescending": "Najnowsze",
+    "releasedYearAscending": "Rok wydania (Rosnąco)",
+    "releasedYearDescending": "Rok wydania (Malejąco)",
+    "allTimeMostListened": "Najczęściej słuchane (Cały okres)",
+    "allTimeLeastListened": "Najrzadziej słuchane (Cały okres)",
+    "monthlyMostListened": "Najczęściej słuchane (Ten miesiąc)",
+    "monthlyLeastListened": "Najrzadziej słuchane (Ten miesiąc)",
+    "artistNameAscending": "Nazwa wykonawcy (A do Z)",
+    "artistNameDescending": "Nazwa wykonawcy (Z do A)",
+    "albumNameAscending": "Nazwa albumu (A do Z)",
+    "albumNameDescending": "Nazwa albumu (Z do A)",
+    "noOfSongsDescending": "Najwięcej utworów",
+    "noOfSongsAscending": "Najmniej utworów",
+    "blacklistedFolders": "Wykluczone foldery",
+    "whitelistedFolders": "Dozwolone foldery",
+    "mostLovedDescending": "Najbardziej lubiane",
+    "mostLovedAscending": "Najmniej lubiane",
+    "trackNoAscending": "Numer ścieżki (Rosnąco)",
+    "trackNoDescending": "Numer ścieżki (Malejąco)",
+    "addedOrder": "Kolejność dodania"
+  },
+
+  "filterTypes": {
+    "notSelected": "Nie wybrano",
+    "blacklistedSongs": "Wykluczone utwory",
+    "whitelistedSongs": "Dopuszczone utwory",
+    "favorites": "Ulubione",
+    "nonFavorites": "Nieulubione"
+  },
+
+  "equalizerPresets": {
+    "custom": "Własny",
+    "flat": "Płaski",
+    "acoustic": "Akustyczny",
+    "bassBooster": "Wzmocnienie basu",
+    "bassReducer": "Redukcja basu",
+    "classical": "Klasyczny",
+    "club": "Klubowy",
+    "dance": "Taneczny",
+    "deep": "Głęboki",
+    "electronic": "Elektroniczny",
+    "hipHop": "Hip Hop",
+    "jazz": "Jazz",
+    "latin": "Latino",
+    "live": "Na żywo",
+    "loudness": "Głośność",
+    "lounge": "Lounge",
+    "metal": "Metal",
+    "piano": "Pianino",
+    "pop": "Pop",
+    "reggae": "Reggae",
+    "rnb": "R&B",
+    "rock": "Rock",
+    "ska": "Ska",
+    "smallSpeakers": "Małe głośniki",
+    "soft": "Łagodne",
+    "softRock": "Soft Rock",
+    "spokenWord": "Głos",
+    "techno": "Techno",
+    "trebleBooster": "Wzmocnienie sopranów",
+    "trebleReducer": "Redukcja sopranów",
+    "vocalBooster": "Wzmocnienie wokalu"
+  },
+
+  "song": {
+    "showInFileExplorer": "Pokaż w Eksploratorze Plików",
+    "artwork": "Okładka utworu",
+    "selectedSongCount": "Wybrano {{count}} $t(common.song, {\"count\":{{count}}})",
+    "likeSong": "Dodaj do ulubionych",
+    "unlikeSong": "Usuń z ulubionych",
+    "toggleLikeSongs": "Dodaj/usuń utwory z ulubionych",
+    "addToPlaylists": "Dodaj do playlist(y)",
+    "goToAlbum": "Przejdź do albumu",
+    "editSongTags": "Edytuj tagi utworu",
+    "reparseSong": "Przeanalizuj utwór ponownie",
+    "blacklistSong_one": "Wyklucz utwór",
+    "blacklistSong_other": "Wyklucz utwory",
+    "deblacklist": "Przywróć z wykluczonych",
+    "delete": "Usuń z dysku",
+    "playingNext": "Zagrany jako następny:",
+    "playingNow": "Teraz odtwarzany",
+    "blacklisted": "Wykluczony",
+    "likedThisSong": "Polubiłeś(aś) ten utwór",
+    "dislikedThisSong": "Nie polubiłeś(aś) tego utworu"
+  },
+
+  "artist": {
+    "playAllSongs": "Odtwórz wszystkie utwory",
+    "toggleLikeArtists": "Dodaj/usuń wykonawców z ulubionych",
+    "likeArtist": "Dodaj wykonawcę do ulubionych",
+    "dislikeArtist": "Usuń wykonawcę z ulubionych",
+    "selectedArtistCount": "Wybrano {{count}} $t(common.artist, {\"count\":{{count}}})"
+  },
+
+  "folder": {
+    "toggleBlacklistFolder": "Przełącz wykluczenie folderu",
+    "blacklistFolder": "Wyklucz folder",
+    "selectedFolderCount": "Wybrano {{count}} $t(common.folder, {\"count\":{{count}}})",
+    "selectedParentFolderCount_one": "{{count}} wybrany folder nadrzędny",
+    "selectedParentFolderCount_other": "{{count}} wybranych folderów nadrzędnych",
+    "directoryCount_one": "{{count}} katalog",
+    "directoryCount_other": "{{count}} katalogów",
+    "selectedDirectoryCount_one": "{{count}} wybrany katalog",
+    "selectedDirectoryCount_other": "{{count}} wybranych katalogów"
+  },
+
+  "playlist": {
+    "changeArtwork": "Zmień okładkę",
+    "addArtwork": "Dodaj okładkę",
+    "playlistArtworkUpdateSuccess": "Pomyślnie zaktualizowano okładkę playlisty.",
+    "renamePlaylist": "Zmień nazwę playlisty",
+    "exportPlaylist": "Eksportuj playlistę",
+    "deleteSelectedPlaylists": "Usuń zaznaczone playlisty",
+    "deletePlaylist_one": "Usuń playlistę",
+    "deletePlaylist_other": "Usuń playlisty",
+    "selectedPlaylistCount": "Wybrano {{count}} $t(common.playlist, {\"count\":{{count}}})",
+    "empty": "Wygląda na to, że ta playlista jest pusta."
+  },
+
+  "album": {
+    "selectedAlbumCount": "Wybrano {{count}} $t(common.album, {\"count\":{{count}}})"
+  },
+
+  "genre": {
+    "selectedGenreCount": "Wybrano {{count}} $t(common.genre, {\"count\":{{count}}})"
+  },
+
+  "homePage": {
+    "empty": "Pusto tu...",
+    "emptyDescription": "Wygląda na to, że nie dodałeś(aś) jeszcze żadnych folderów z muzyką do Twojej biblioteki.",
+    "loading": "Chwilunia. Przygotowujemy wszystko dla Ciebie...",
+    "listenMoreToShowMetrics": "Przesłuchaj więcej utworów, aby zobaczyć dodatkowe statystyki.",
+
+    "recentlyAddedSongs": "Ostatnio dodane utwory",
+    "recentlyPlayedSongs": "Ostatnio odtwarzane utwory",
+    "recentArtists": "Ostatni wykonawcy",
+    "mostLovedSongs": "Najbardziej lubiane utwory",
+    "mostLovedArtists": "Najbardziej lubieni wykonawcy",
+
+    "openSongsWithNewestSortOption": "Otwiera „Utwory” z opcją sortowania „Najnowsze”.",
+    "openPlaybackHistory": "Otwiera playlistę 'Historia' z opcją sortowania „Kolejność dodania”",
+    "openFavoritesWithAllTimeMostListenedSortOption": "Otwiera playlistę „Ulubione” z opcją sortowania „Najczęściej słuchane (cały okres)”",
+
+    "noSongsAvailable": "Brak dostępnych utworów",
+    "stayCalm": "Prosze się uspokoić",
+    "favoritesAndRecaps": "Ulubione i Podsumowania"
+  },
+
+  "searchPage": {
+    "addFolder": "Dodaj folder",
+    "enablePredictiveSearch": "Włącz wyszukiwanie predykcyjne",
+    "disablePredictiveSearch": "Wyłącz wyszukiwanie predykcyjne",
+    "searchForAnything": "Szukaj czegokolwiek",
+    "searchForAnythingInLibrary": "Szukaj czegokolwiek w bibliotece",
+    "separateKeywords": "Użyj ' ; ', aby oddzielić frazy wyszukiwania.",
+    "allFilter": "Wszystkie",
+    "mostRelevant": "Najtrafniejsze",
+    "resultCount_one": "{{count}} wynik",
+    "resultCount_other": "{{count}} wyników",
+    "resultAndVisibleCount_other": "{{count}} wyników ($t(common.shownWithCount, {\"count\":{{noVisible}}}))",
+    "noResults": "Nie znaleziono niczego pasującego do Twojego zapytania.",
+    "recentSearchResultTooltipLabel": "Szukaj '{{value}}'",
+    "showingResultsFor": "Wyniki dla <span>'{{query}}'</span>",
+    "showingResultsForWithFilter": "Wyniki dla <span>'{{query}}'</span> w kategorii <span>{{filter}}</span>",
+
+    "a": "Szukaj czegokolwiek"
+  },
+
+  "songsPage": {
+    "loading": "Chwilunia. Przygotowujemy wszystko dla Ciebie...",
+    "empty": "Pusto tu..."
+  },
+
+  "artistsPage": {
+    "empty": "Pusto tu..."
+  },
+
+  "foldersPage": {
+    "addFolder": "Dodaj folder",
+    "musicFolders": "Foldery z muzyką",
+    "empty": "Brak dodanych folderów w Twojej bibliotece."
+  },
+
+  "playlistsPage": {
+    "createNewPlaylist": "Utwórz nową playlistę",
+    "importPlaylist": "Importuj playlistę",
+    "addPlaylist": "Dodaj playlistę",
+    "removeFromThisPlaylist": "Usuń z tej playlisty",
+    "removeSongFromPlaylistSuccess": "Usunięto `{{title}}` z '{{playlistName}}'",
+    "createdOn": "Utworzono {{val, datetime}}",
+    "clearSongHistoryConfirm": "Wyczyść historię odtwarzania",
+    "clearSongHistoryConfirmNotice": "Czy na pewno chcesz wyczyścić swoją historię odtwarzania? Tej operacji nie można cofnąć.",
+    "clearSongHistorySuccess": "Historia odtwarzania została wyczyszczona pomyślnie.",
+    "empty": "Nie utworzono jeszcze żadnych playlist.",
+
+    "favorites": "Ulubione",
+    "history": "Historia"
+  },
+
+  "albumsPage": {
+    "empty": "Pusto tu..."
+  },
+
+  "genresPage": {
+    "empty": "Pusto tu..."
+  },
+
+  "settingsPage": {
+    "settings": "Ustawienia",
+
+    "appearance": "Wygląd",
+    "changeTheme": "Zmień motyw aplikacji według własnych preferencji.",
+    "lightTheme": "Jasny motyw",
+    "darkTheme": "Ciemny motyw",
+    "systemTheme": "Motyw systemowy",
+
+    "enableImageBasedDynamicThemes": "Włącz motywy dynamiczne",
+    "enableImageBasedDynamicThemesDescription": "Zmieniaj motyw aplikacji dynamicznie na podstawie motywu okładki aktualnie odtwarzanego utworu.",
+
+    "language": "Język",
+    "languageDescription": "Wybierz język wyświetlania interfejsu Nora.",
+
+    "audioPlayback": "Odtwarzanie dźwięku",
+    "showRemainingSongDuration": "Pokaż pozostały czas utworu",
+    "showRemainingSongDurationDescription": "Wyświetla czas pozostały do końca utworu zamiast czasu odtwarzania, który upłynął.",
+    "playbackRate": "Prędkość odtwarzania",
+    "changePlaybackRate": "Zmień domyślną prędkość odtwarzania.",
+    "resetPlaybackRate": "Zresetuj do 1x",
+    "seekbarScrollInterval": "Zmień skok przewijania kółkiem myszy nad paskiem postępu i głośności.",
+    "second": "sekunda",
+    "second_other": "sekund",
+
+    "accounts": "Konta",
+    "integrateLastFm": "Zintegruj LastFM z Norą.",
+    "lastFmLogo": "Logo LastFM",
+    "lastFmConnected": "Połączono z LastFM",
+    "lastFmNotConnected": "Nie połączono z LastFM",
+    "loggedInAs": "Zalogowano jako",
+    "lastFmDescription1": "Połącz z LastFM, aby włączyć Scrobbling.",
+    "lastFmDescription2": "Scrobbling to sposób na wysyłanie informacji o muzyce, której użytkownik słucha.",
+    "lastFmDescription3": "Kiedy słuchasz utworu, LastFM go „Scrobbluje” i dodaje do Twojego profilu.",
+    "lastFmDescription4": "Ta funkcja wymaga połączenia z internetem.",
+    "authenticateAgain": "Uwierzytelnij ponownie",
+    "loginInBrowser": "Zaloguj się przez przeglądarkę",
+    "scrobblingDescription": "Włącz Scrobbling LastFM, aby wysyłać dane o tym jak słuchasz utworów.",
+    "enableScrobbling": "Włącz Scrobbling LastFM",
+    "sendFavoritesToLastFmDescription": "Wysyłaj informacje o ulubionych utworach do LastFM kiedy oznaczysz je jako polubione albo nielubiane.",
+    "sendFavoritesToLastFm": "Wysyłaj dane o ulubionych utworach",
+    "sendNowPlayingToLastFmDescription": "Wysyłaj informację o aktualnie odtwarzanym utworze do LastFM automatycznie po rozpoczęciu odtwarzania.",
+    "sendNowPlayingToLastFm": "Wysyłaj dane o aktualnie granym utworze",
+    "enableDiscordRpcDescription": "Zintegruj Discord Rich Presence z Norą",
+    "enableDiscordRpc": "Włącz Discord Rich Presence",
+
+    "doNotSaveLyricsAutomatically": "Nie zapisuj tekstów automatycznie",
+    "syncedLyricsOnly": "Tylko zsynchronizowane",
+    "saveEitherLyrics": "Zsynchronizowane lub zwykłe",
+    "lyrics": "Teksty utworów",
+    "enableMusixmatchLyricsDescription": "Włącz teksty utworów z Musixmatch, który dostarcza zsynchronizowane i niezsynchronizowane teksty Twoich piosenek na żądanie.",
+    "musixmatchDisclaimerNotice": "Włączenie i użycie tej funkcji oznacza, że zgadzasz się z <Button>Zastrzeżenieniami Musixmatch</Button> dotyczącymi tekstów utworów.",
+    "editMusixmatchSettings": "Edytuj ustawienia Musixmatch",
+    "enableMusixmatch": "Włącz teksty Musixmatch",
+    "musixmatchEnabled": "Teksty Musixmatch są włączone",
+    "saveLyricsAutomaticallyDescription": "Wybierz opcję automatycznego zapisywania tekstów utworów przy ich pobraniu.",
+    "saveLyricsAutomaticallyInfo": "Automatycznie pobrane teksty zostaną zapisane po zakończeniu utworu, aby uniknąć uszkodzenia plików.",
+    "saveLyricsInLrcFilesDescription": "Włącz zapisywanie tekstów w plikach LRC dla utworów, które wspierają edytowanie metadanych. W przeciwnym wypadku, Nora zapisze tekst w pliku LRC.",
+    "saveLyricsInLrcFiles": "Zapisuj teksty wspieranych utworów również w plikach LRC",
+    "autoTranslateLyricsDescription": "Włącz automatyczne tłumaczenie tekstów utworów na Twój wybrany język. Teksty zostaną automatycznie przetłumaczone nawet jeśli sa one już w takim samym języku, co przez Ciebie wybrany.",
+    "autoTranslateLyrics": "Automatyczne tłumaczenie tekstów",
+    "autoConvertLyricsDescription": "Włącz automatyczną transkrypcję tekstów na alfabet łaciński. Obecnie Nora obsługuje konwersję języka japońskiego, chińskiego i koreańskiego.",
+    "autoConvertLyrics": "Automatyczna konwersja tekstów",
+    "lrcFileCustomSaveLocationDescription": "Wybierz niestandardową lokalizację zapisu plików LRC, jeśli nie chcesz zapisywać ich w tym samym folderze, co powiązany utwór.",
+    "selectedCustomLocation": "Wybrana niestandardowa lokalizacja",
+    "setCustomLocation": "Ustaw niestandardową lokalizację",
+
+    "equalizer": "Korektor (Equalizer)",
+    "reset": "Zresetuj",
+
+    "defaultPage": "Strona startowa",
+    "changeDefaultPageDescription": "Zmień domyślną stronę, którą chcesz widzieć po uruchomieniu aplikacji.",
+
+    "preferences": "Preferencje",
+    "songIndexingDescription": "Włącza numerowanie utworów na stronach, nadając numer każdej piosence w zakładce Piosenki.",
+    "enableSongIndexing": "Włącz numerowanie utworów",
+    "showTrackNumberAsSongIndexDescription": "Pokazuje numer utworu przed nim samym na stronie albumów.",
+    "showTrackNumberAsSongIndex": "Pokaż numer utworu jako jego indeks",
+    "showArtistArtworkNearSongControlsDescription": "Pokazuje zdjęcie wykonawcy obok tytułu na panelu sterowania.",
+    "showArtistArtworkNearSongControls": "Pokaż dostępne zdjęcia wykonawców przy ich nazwach (w lewym dolnym rogu).",
+    "disableBackgroundArtworksDescription": "Wyłącza duże grafiki w tle na niektórych stronach.",
+    "disableBackgroundArtworks": "Wyłącz grafiki w tle",
+    "playlistArtworksDescription": "Zmień zachowanie grafik utworzonych z okładek utworów.",
+    "enablePlaylistArtworks": "Włącz grafiki utworzonych z okładek dla playlist",
+    "shuffleArtworkFromSongCovers": "Włącz losowanie grafik utworzonych z okładek utworów (zmienia się przy odświeżeniu).",
+
+    "accessibility": "Dostępność",
+    "reducedMotionDescription": "Usuwa animacje w aplikacji. Zmniejszy to też płynność aplikacji.",
+    "enableReducedMotion": "Włącz redukcję ruchu",
+
+    "performance": "Wydajność",
+    "removeAnimationOnBatteryDescription": "Usuwa animacje, gdy system działa na baterii.",
+    "removeAnimationOnBattery": "Wyłącz animacje na baterii",
+    "allowToPreventScreenSleepingDescription": "Pozwól Norze zapobiegać wygaszaniu ekranu w sytuacjach braku aktywności użytkownika, jak wyświetlanie tekstu utworu.",
+    "allowToPreventScreenSleeping": "Zapobiegaj usypianiu ekranu",
+
+    "startupAndWindowCustomization": "Uruchamianie i okna",
+    "autoLaunchAtStartDescription": "Automatycznie uruchamiaj Norę po zalogowaniu do systemu.",
+    "autoLaunchAtStart": "Uruchamiaj przy starcie systemu",
+    "hideWindowAtStartDescription": "Czy Nora ma być widoczna po uruchomieniu.",
+    "hideWindowAtStart": "Uruchamiaj zminimalizowane do zasobnika (Tray)",
+    "hideWindowOnCloseDescription": "Zachowanie przycisku zamknięcia okna.",
+    "hideWindowOnClose": "Minimalizuj do zasobnika po zamknięciu",
+    "trayClickBehaviorDescription": "Ustaw zachowanie ikony w zasobniku systemowym.",
+    "traySingleClickTogglesWindow": "Pojedyncze kliknięcie przełącza okno odtwarzacza.",
+
+    "storage": "Pamięć",
+    "storageDescription": "Zobacz jak Nora zarządza biblioteką i wykorzystuje miejsce na Twoim dysku.",
+
+    "fullStorageSpace": "Całkowite użycie",
+    "fullStorageOutOfUsage": "{{value}} z {{total}}",
+    "freeSpace": "Wolne miejsce",
+    "otherApplications": "Inne aplikacje",
+    "artworkCache": "Pamięć podręczna grafik",
+    "tempArtworkCache": "Tymczasowa pamięć grafik",
+    "databaseData": "Baza danych",
+    "songsData": "Dane utworów",
+    "artistsData": "Dane wykonawców",
+    "albumsData": "Dane albumów",
+    "playlistsData": "Dane playlist",
+    "palettesData": "Dane palet kolorów",
+    "genresData": "Dane gatunków",
+    "appLogs": "Logi aplikacji",
+    "userData": "Dane użytkownika",
+    "internalAppFiles": "Wewnętrzne pliki aplikacji",
+    "storageUseForLibraryData": "Użycie pamięci przez bibliotekę",
+    "otherAppFiles": "Pliki innych aplikacji",
+    "generated": "Wygenerowano",
+    "generateStorageMetrics": "Generuj statystyki pamięci",
+    "generateStorageMetricsAgain": "Generuj ponownie statystyki pamięci",
+    "noStorageMetrics": "Wygląda na to, że nie wygenerowano jeszcze statystyk pamięci.",
+    "storageMetricsGenerationDisclaimer": "Generowanie statystyk to stosunkowo wymagające obliczeniowo zadanie, co znaczy, że Nora może chwilowo nie odpowiadać. Prosimy zachować cierpliwość...",
+    "storageMetricsGenerationError": "Wygląda na to, że coś poszło z naszej strony nie tak. Prosimy zgłosić to do dewelopera.",
+
+    "advanced": "Zaawansowane",
+    "saveVerboseLogsDescription": "Zapisuj szczegółowe logi debugowania. Zwiększy to rozmiar logów.",
+    "saveVerboseLogs": "Zapisuj szczegółowe logi",
+
+    "about": "O aplikacji",
+    "releasedOn": "Wydano dnia {{val, datetime}}",
+    "noraWebsite": "Oficjalna strona internetowa Nory",
+    "noraDiscordServer": "Oficjalny Serwer Discord Nory",
+    "noraGithubRepo": "Repozytorium Github Nory",
+    "noraGithubIssues": "Zgłoszenia (Issues) na Githubie",
+    "noraLocalizationStatus": "Status tłumaczeń Nory",
+    "noraDescription": "Nora to elegancki odtwarzacz muzyki zbudowany przy użyciu o Electron i React.",
+    "noraInspiration": "Zainspirowane przez <Hyperlink>Oto Music for Android</Hyperlink> autorstwa Piyush Mamidwar.",
+    "otoMusicOnPlayStore": "Oto Music dla Androida w Sklepie Play",
+    "noraLicenseNotice": "Ten produkt jest licencjonowany na <Button>licencji MIT.</Button>",
+    "appLicense": "Licencja aplikacji",
+    "releaseNotes": "Informacje o wydaniu",
+    "openSourceLicenses": "Licencje Open-Source",
+    "openLogFile": "Otwórz plik logów",
+    "openDevtools": "Otwórz narzędzia deweloperskie",
+    "resyncLibrary": "Synchronizuj ponownie bibliotekę",
+    "generatePalettes": "Generuj palety kolorów",
+    "appShortcuts": "Skróty w aplikacji",
+
+    "resetApp": "Zresetuj aplikację",
+    "clearOptionalData": "Wyczyść dane opcjonalne",
+    "clearHistory": "Wyczyść historię",
+    "confirmSongHistoryDeletion": "Wyczyść historię odtwarzania",
+    "songHistoryDeletionDisclaimer": "Czy na pewno chcesz usunąć historię odtwarzania? Tej akcji nie można cofnąć.",
+    "songHistoryDeletionSuccess": "Historia odtwarzania została wyczyszczona pomyślnie.",
+    "exportAppData": "Eksportuj dane aplikacji",
+    "importAppData": "Importuj dane aplikacji",
+    "createIssueOnNoraGithubRepo": "utwórz zgłoszenie w $t(settingsPage.noraGithubRepo)",
+    "contact": "Jeśli masz uwagi na temat błędów, sugestie funkcji, i tak dalej, proszę <Hyperlink>$t(settingsPage.createIssueOnNoraGithubRepo)</Hyperlink>",
+    "emailContact": "lub skontaktuj się ze mną mailowo.",
+    "loveNora": "Stworzone z <span>❤</span> przez <Hyperlink>Sandakan Nipunajith</Hyperlink>.",
+    "sandakanGithubProfile": "Profil Github Sandakana",
+    "beautifulSriLanka": "Piękna Sri Lanka"
+  },
+
+  "artistInfoPage": {
+    "likeArtist": "Polub {{name}}",
+    "dislikeArtist": "Nie lubię {{name}}",
+    "appearsInAlbums": "Występuje w albumach",
+    "appearsInSongs": "Występuje w utworach",
+    "similarArtistsInLibrary": "Podobni wykonawcy w bibliotece",
+    "otherSimilarArtists": "Inni podobni wykonawcy",
+    "viewInLastFm": "Zobacz `{{name}}` w LastFM"
+  },
+
+  "albumInfoPage": {
+    "unavailableTracks": "Niedostępne utwory z tego albumu"
+  },
+
+  "currentQueuePage": {
+    "queue": "Kolejka odtwarzania",
+    "folderWithName": "Folder {{name}}",
+    "enableAutoScrolling": "Włącz automatyczne przewijanie",
+    "disableAutoScrolling": "Wyłącz automatyczne przewijanie",
+    "scrollToCurrentPlayingSong": "Przewiń do aktualnie odtwarzanego utworu",
+    "shuffleQueue": "Wymieszaj kolejkę",
+    "queueShuffleSuccess": "Kolejka wymieszana pomyślnie.",
+    "clearQueue": "Wyczyść kolejkę",
+    "queueCleared": "Kolejka wyczyszczona.",
+    "durationRemaining": "Pozostało {{duration}}",
+    "empty": "Kolejka jest pusta."
+  },
+
+  "lyricsEditingPage": {
+    "lyricsText": "Tekst utworu",
+    "startInSeconds": "Start (sek)",
+    "endInSeconds": "Koniec (sek)",
+    "fromTo": "Od {{start}} do {{end}}",
+    "deleteLine": "Usuń linię",
+    "addLineAbove": "Dodaj linię powyżej",
+    "addLineBelow": "Dodaj linię poniżej",
+    "addInstrumentalLineBelow": "Dodaj linię instrumentalną poniżej",
+    "editLine": "Edytuj linię",
+    "finishEditing": "Zakończ edycję",
+    "resetLyrics": "Zresetuj tekst",
+    "resetLyricsConfirm": "Czy na pewno chcesz zresetować tekst?",
+    "resetLyricsConfirmMessage": "<p>Stracisz <span>ostatnie modyfikacji tekstu utworu</span> oraz <span>dane synchronizacji startu/konca</span>, jeśli kontynuujesz tę akcję.</p> <br/> <p>Ta akcja jest nieodwracalna.</p>",
+    "incorrectSongTitle": "Nieprawidłowy utwór",
+    "incorrectSongMessage": "Aby edytować, odtwórz utwór `{{title}}`.",
+    "lyricsEditor": "Edytor tekstu",
+    "playbackSpeed": "Prędkość",
+    "playbackTime": "Czas",
+    "offsetWithCount": "Przesunięcie {{count}}",
+    "saveLyrics": "Zapisz tekst",
+    "stopAndEditLyrics": "Zatrzymaj i edytuj tekst",
+    "playLyrics": "Odtwórz tekst",
+    "configure": "Konfiguruj"
+  },
+
+  "lyricsPage": {
+    "noLyrics": "Nie znaleziono tekstu.",
+    "noLyricsDescription": "Nie znaleźliśmy tekstu dla tego utworu. Możesz dodać własny w Edytorze Tagów.",
+    "noSyncedLyrics": "Brak zsynchronizowanego tekstu.",
+    "noSyncedLyricsDescription": "Nie znaleziono czasów dla tego tekstu.",
+    "noOnlineLyrics": "Brak tekstu online.",
+    "noOfflineLyrics": "Brak tekstu offline.",
+    "noSavedLyrics": "Brak zapisanego tekstu.",
+    "onlineLyricsRefreshFailed": "Nie udało się odświeżyć tekstu online.",
+    "offlineLyricsForSong": "Tekst offline dla `{{title}}`",
+    "onlineLyricsForSong": "Tekst online dla `{{title}}`",
+    "editLyrics": "Edytuj tekst w edytorze",
+    "translateLyrics": "Przetłumacz tekst",
+    "romanizeLyrics": "Romanizuj japoński tekst utworu",
+    "convertLyricsToPinyin": "Konwertuj chiński tekst utworu na Pinyin",
+    "convertLyricsToRomaja": "Konwertuj koreański tekst na Romaja",
+    "resetLyrics": "Zresetuj tekst",
+    "showOnlineLyrics": "Pokaż tekst online",
+    "refreshOnlineLyrics": "Odśwież tekst online",
+    "showSavedLyrics": "Pokaż zapisany tekst",
+
+    "lyricsLoading": "Szukam tekstu",
+    "lyricsLoadingDescription": "Chwileczkę... Przeszukujemy sieć...",
+    "noInternet": "Brak internetu",
+    "noInternetDescription": "Brak tekstu offline. Potrzebujesz internetu, aby pobrać tekst.",
+    "lyricsProvidedBy": "Tekst dostarczony przez <Hyperlink/>",
+    "lyricsTranslatedBy": "Tekst przetłumaczony przez Tłumacz Google"
+  },
+
+  "songInfoPage": {
+    "listensCount": "{{count}} odsłuchań",
+    "listeningActivityInLastMonths": "Aktywność w ostatnich {{count}} miesiącach",
+    "similarTracksInLibrary": "Podobne utwory w Twojej bibliotece",
+    "otherSimilarTracks": "Inne podobne utwory",
+    "additionalSongInfo": "Dodatkowe informacje o utworze",
+    "allTimeListens": "Liczba odsłuchań (cały okres)",
+    "listensThisMonth": "Liczba odsłuchań (ten miesiąc)",
+    "listensThisYear": "Liczba odsłuchań (ten rok)",
+    "totalSongSkips": "Pominięcia utworu",
+    "fullSongListens": "Pełne odsłuchania",
+    "mostSoughtPosition": "Najczęściej odtwarzany moment",
+    "mostSoughtFrequency": "Liczba powtórzeń",
+    "lovedSong": "Polubiłeś(aś) ten utwór",
+    "unlovedSong": "Nie polubiłeś(aś) tego utworu",
+    "byArtists": " <By>autorstwa</By> <span>{{val, list}}</span>"
+  },
+
+  "songTagsEditingPage": {
+    "editArtwork": "Edytuj okładkę",
+    "removeArtwork": "Usuń okładkę",
+    "lyricsIncluded": "Zawiera tekst",
+    "addToMetadata": "Dodaj do metadanych",
+    "customizeMetadata": "Dostosuj metadane",
+    "songMetadataEditor": "Edytor metadanych utworu",
+    "searchMetadataOnInternet": "Szukaj metadanych w internecie",
+    "saveTags": "Zapisz tagi metadanych",
+    "updateAddedToBeSavedLater": "Aktualizacje metadanych aktualnie odtwarzanego utworu zostaną zapisane po jego zakończeniu.",
+    "pendingUpdateAvailable": "Aktualizacja tego utworu oczekuje na zapisanie.",
+    "saveTagsNotSupportedTitle": "Nieobsługiwane",
+    "saveTagsNotSupportedDescription": "<P1>Nora nie obsługuje edycji metadanych w formacie <Format/>.</P1><P2>Obecnie obsługiwany jest tylko format <SupportedFormat/>.",
+    "albumArtistNotMentioned": "Utwór jest już częścią albumu `{{title}}`, ale wykonawca `{{artists}}` nie jest oznaczony jako wykonawca albumu.",
+    "songAlbumArtistMismatch": "Wykonawcy wybranego albumu '{{albumArtists}}' nie pasują do artystów albumu '{{albumTitle}}' - '{{songAlbumArtists}}'.",
+    "searchForArtists": "Szukaj wykonawców",
+    "searchForAlbums": "Szukaj albumów",
+    "searchForGenres": "Szukaj gatunków",
+    "addNewArtist": "Dodaj nowego wykonawcę `{{name}}`",
+    "addNewAlbum": "Dodaj nowy album `{{name}}`",
+    "addNewGenre": "Dodaj nowy gatunek `{{name}}`",
+    "albumName": "Nazwa albumu",
+    "songArtists": "Wykonawcy utworu",
+    "songName": "Tytuł utworu",
+    "composer": "Kompozytor",
+    "syncedLyricsFetchFailed": "Nie udało się pobrać tekstu.",
+    "lyricsEnhancedSynced": "Tekst ma rozszerzoną synchronizację.",
+    "lyricsNotEnhancedSynced": "Tekst nie ma rozszerzonej synchronizacji.",
+    "enhancedLyricsSupported": "Obsługa rozszerzonych tekstów.",
+    "readMoreAboutLrc": "$t(common.readMoreAboutTitle, {\"title\": \"format LRC\"})",
+    "avoidUnsyncedOnSyncedLyricsTab": "Unikaj wpisywania niezsynchronizowanego tekstu w zakładce tekstu zsynchronizowanego.",
+    "avoidSyncedOnUnsyncedLyricsTab": "Unikaj wpisywania zsynchronizowanego tekstu w zakładce tekstu niezsynchronizowanego.",
+    "pendingLyricsSavesAvailable": "Oczekujące zmiany tekstu zostaną zapisane po zakończeniu odtwarzania utworu.",
+    "downloadLyrics": "Pobierz tekst",
+    "downloadSyncedLyrics": "Pobierz tekst zsynchronizowany",
+    "musixmatchNotEnabled": "Musisz włączyć teksty utworów z Musixmatch w ustawieniach, aby użyć tej funkcji."
+  },
+
+  "miniPlayer": {
+    "alwaysOnTopEnabled": "Zawsze na wierzchu: WŁ",
+    "alwaysOnTopDisabled": "Zawsze na wierzchu: WYŁ"
+  },
+
+  "time": {
+    "second_one": "sekunda",
+    "second_other": "sekund",
+    "minute_one": "minuta",
+    "minute_other": "minut",
+    "hour_one": "godzina",
+    "hour_other": "godzin",
+    "day_one": "dzień",
+    "day_other": "dni",
+    "month_one": "miesiąc",
+    "month_other": "miesięcy",
+    "year_one": "rok",
+    "year_other": "lat",
+    "secondWithCount": "{{count}} $t(time.second, {\"count\":{{count}}})",
+    "minuteWithCount": "{{count}} $t(time.minute, {\"count\":{{count}}})",
+    "hourWithCount": "{{count}} $t(time.hour, {\"count\":{{count}}})",
+    "dayWithCount": "{{count}} $t(time.day, {\"count\":{{count}}})",
+    "monthWithCount": "{{count}} $t(time.month, {\"count\":{{count}}})",
+    "yearWithCount": "{{count}} $t(time.year, {\"count\":{{count}}})"
+  },
+
+  "elapsedTime": {
+    "second_one": "{{count}} sekundę temu",
+    "second_other": "{{count}} sekund temu",
+    "minute_one": "{{count}} minutę temu",
+    "minute_other": "{{count}} minut temu",
+    "hour_one": "{{count}} godzinę temu",
+    "hour_other": "{{count}} godzin temu",
+    "day_one": "{{count}} dzień temu",
+    "day_other": "{{count}} dni temu",
+    "month_one": "{{count}} miesiąc temu",
+    "month_other": "{{count}} miesięcy temu",
+    "year_one": "{{count}} rok temu",
+    "year_other": "{{count}} lat temu"
+  },
+
+  "month": {
+    "january": "Styczeń",
+    "february": "Luty",
+    "march": "Marzec",
+    "april": "Kwiecień",
+    "may": "Maj",
+    "june": "Czerwiec",
+    "july": "Lipiec",
+    "august": "Sierpień",
+    "september": "Wrzesień",
+    "october": "Październik",
+    "november": "Listopad",
+    "december": "Grudzień"
+  },
+
+  "data": {
+    "byteWithCount_one": "{{count}} bajt",
+    "byteWithCount_other": "{{count}} bajtów"
+  },
+
+  "sideBar": {
+    "home": "Start",
+    "search": "Szukaj"
+  },
+
+  "renamePlaylistPrompt": {
+    "renamePlaylistWithName": "Zmień nazwę playlisty `{{name}}`",
+    "playlistName": "Nazwa playlisty"
+  },
+
+  "newPlaylistPrompt": {
+    "addPlaylistSuccess": "Playlista została dodana.",
+    "playlistNameEmpty": "Nazwa playlisty jest wymagana",
+    "addNewPlaylist": "Dodaj nową playlistę"
+  },
+
+  "confirmDeletePlaylistsPrompt": {
+    "playlistsDeletedWithCount": "Usunięto $t(common.playlistWithCount, {\"count\":{{count}}}).",
+    "confirmPlaylistDeleteWithCount": "Potwierdź usunięcie $t(common.playlistWithCount, {\"count\":{{count}}})",
+    "message_one": "Usunięcie tej playlisty usunie powiązania utworów w niej zawartych. Nie będziesz już mieć do niej dostępu, jeśli ją usuniesz.",
+    "message_other": "Usunięcie tych playlist usunie powiązania utworów w nich zawartych. Nie będziesz mieć już do nich dostępu, jeśli je usuniesz.",
+    "modificationNotice": "Ta akcja wpłynie na następujące pliki: "
+  },
+
+  "resetAppConfirmationPrompt": {
+    "confirmAppReset": "Potwierdź reset aplikacji",
+    "message": "Reset aplikacji usunie wszystkie dane użytkownika, w tym dane związane z utworami, ulubionymi, ustawienia itp., ale NIE usunie plików muzycznych. Ta akcja jest <span>NIEODWRACALNA</span>.",
+    "restartAfterReset": "Nora uruchomi się ponownie po resecie.",
+    "systemPlaylistsRemovalProhibited": "Nie możesz usunąć playlist takich jak Historia czy Ulubione."
+  },
+
+  "addSongsToPlaylistsPrompt": {
+    "songsAddedToPlaylists": "Dodano $t(common.songWithCount, {\"count\":{{count}}}) do $t(common.playlistWithCount, {\"count\":{{playlistCount}}})",
+    "selectPlaylistsToAdd": "Wybierz playlisty, aby dodać $t(common.songWithCount, {\"count\":{{count}}})",
+    "duplicationNotice": "Gdy dodajesz kilka utworów do playlist, utwory, które są już w wybranych playlistach zostaną pominięte."
+  },
+
+  "blacklistSongConfirmPrompt": {
+    "title": "Potwierdź wykluczenie $t(common.songWithCount, {\"count\":{{count}}}) z biblioteki",
+    "message_one": "Zamierzasz wykluczyć ten utwór z bilbioteki. Możesz go przywrócić, klikając w niego prawym przyciskiem myszy i wybierając '$t(song.deblacklist)'. Nie będzie to miało wpływu na twoje dane związane z tym utworem.",
+    "message_other": "Zamierzasz wykluczyć te utwory z bilbioteki. Możesz je przywrócić, klikając w nie prawym przyciskiem myszy i wybierając '$t(song.deblacklist)'. Nie będzie to miało wpływu na twoje dane związane z tymi utworami.",
+    "effectTitle": "Co robi wykluczenie utworu",
+    "effect1": "W bibliotece będzie widoczny jako wyszarzony i oznaczony symbolem '<span/>'.",
+    "effect2": "Nie będzie automatycznie dodawany do kolejki, ani przez <span>'$t(common.shuffleAndPlay)'</span> lub <span>'$t(common.playAll)'</span>, chyba że własnoręcznie je dodasz.",
+    "effect3": "Nadal będzie można go odtworzyć klikając podwójnie na niego lub używając <span>'$t(common.play)'</span> albo <span>'$t(common.playNext)'.</span>",
+    "songsBlacklisted": "Wykluczono i usunięto z biblioteki: $t(common.songWithCount, {\"count\":{{count}}})"
+  },
+
+  "blacklistFolderConfirmPrompt": {
+    "title": "Potwierdź wykluczenie $t(common.folderWithCount, {\"count\":{{count}}}) z biblioteki",
+    "message_one": "Zamierzasz wykluczyć ten folder. Możesz go przywrócić, klikając w niego prawym przyciskiem myszy i wybierając '$t(song.deblacklist)'. Nie będzie to miało wpływu na twoje dane związane z tym folderem.",
+    "message_other": "Zamierzasz wykluczyć te foldery. Możesz je przywrócić, klikając w nie prawym przyciskiem myszy i wybierając '$t(song.deblacklist)'. Nie będzie to miało wpływu na twoje dane związane z tymi folderami.",
+    "effectTitle": "Co robi wykluczenie folderu",
+    "effect1": "W bibliotece będzie widoczny jako wyszarzony i oznaczony symbolem '<span/>'.",
+    "effect2": "Piosenki powiązane z tym folderem zostaną również wykluczone.",
+    "effectTitle2": "Co dzieje się z piosenkami powiązanymi z wykluczonym folderem",
+    "folderBlacklisted": "Wykluczono: $t(common.folderWithCount, {\"count\":{{count}}})."
+  },
+
+  "deleteSongFromSystemConfirmPrompt": {
+    "title_one": "Usuń `{{title}}` z systemu",
+
+    "title_other": "Usuń $t(common.songWithCount, {\"count\":{{count}}}) z systemu",
+    "permanentlyDeleteFromSystem": "Permanentnie usuń z systemu",
+    "message_one": "Stracisz ten utwór ze swojego systemu i możesz nie być w stanie go później odzyskać, jeśli wybierzesz opcję systemu '$t(deleteSongFromSystemConfirmPrompt.permanentlyDeleteFromSystem)'.",
+    "message_other": "Stracisz te utwory ze swojego systemu i możesz nie być w stanie ich później odzyskać, jeśli wybierzesz opcję systemu '$t(deleteSongFromSystemConfirmPrompt.permanentlyDeleteFromSystem)'.",
+    "modificationNotice": "Ta akcja dotyczy następujących plików:",
+    "deleteSong": "Usuń utwór",
+    "songPermanentlyDeleted": "Usunięto $t(common.songWithCount, {\"count\":{{count}}}) z systemu.",
+    "songMovedToBin": "Przeniesiono $t(common.songWithCount, {\"count\":{{count}}}) do kosza."
+  },
+
+  "addMusicFoldersPrompt": {
+    "title": "Wybierz foldery do dodania",
+    "emptyMessage1": "Wygląda na to, że nie wybrałeś(aś) żadnych folderów.",
+    "emptyMessage2": "Wybierz foldery z Twojego systemu. Pojawią się one tutaj, aby można było je dalej dostosować.",
+    "chooseFolders": "Wybierz foldery",
+    "addSelectedFolders": "Dodaj wybrane foldery",
+    "noFoldersSelected": "Nie wybrano folderów. (Muszą mieć jeden folder nadrzędny)"
+  },
+
+  "removeFolderConfirmationPrompt": {
+    "title": "Potwierdź usunięcie folderu `{{folderName}}`",
+    "message": "Jesteś pewny(a), że chcesz usunąć ten folder z biblioteki? Usunie to wszystkie dane związane z tym folderem, włącznie z danymi o utworach z biblioteki. Pliki na Twoim systemie pozostaną nienaruszone.",
+    "removeFolder": "Usuń folder"
+  },
+
+  "lyricsEditorHelpPrompt": {
+    "title": "Jak używać edytora tekstu Nory",
+    "subTitle1": "Jak zacząć korzystać z edytora?",
+    "subTitle1Message": " <ol><li>Odtwórz utwór, którego tekst próbujesz edytować. (Jeśli nie będziesz na właściwym utworze, aplikacja zablokuje dodawanie błędnych metadanych do linii tekstu.)</li><li>Kliknij w obszar strony, aby ustawić na niej fokus. (Fokus na stronie jest wymagany, aby skróty klawiszowe specyficzne dla tej strony działały poprawnie.)</li><li>Zacznij odtwarzać utwór od początku. Jeśli chcesz mieć większą kontrolę nad odtwarzaniem, ustaw powtarzanie bieżącego utworu.</li><li>Gdy w utworze padają słowa z danej linii tekstu, naciśnij <ShortcutButton>$t(appShortcutsPrompt.enterKey)</ShortcutButton>, aby podświetlić następną linię i dodać znacznik czasu rozpoczęcia.</li><li>Kontynuuj aż do ostatniej linijki tekstu.</li></ol>",
+    "subTitle2": "Jakie skróty klawiszowe mogę używać w edytorze tekstu?",
+    "subTitle2Message": "Przejdź do <Button>Podpowiedzi skrótów</Button>, aby zobaczyć odpowiednie skróty, których można używać w edytorze tekstu.",
+    "subTitle3": "Czy pominąłem linię?",
+    "subTitle3Message": "<ol><li>Zatrzymaj utwór.</li><li>Znajdź odpowiednią linię tekstu.</li><li>Kliknij przycisk <ShortcutButton>Edytuj</ShortcutButton> pod tą linią i wprowadź niezbędne zmiany.</li><li>Po wprowadzeniu zmian kliknij <ShortcutButton>$t(lyricsEditingPage.finishEditing)</ShortcutButton>, aby zakończyć edycję.</li></ol>",
+    "subTitle4": "Dodałem złe dane do złej linii?"
+  },
+
+  "lyricsEditorSavePrompt": {
+    "lyricsUpdateSuccess": "Tekst zaktualizowany pomyślnie.",
+    "saveEditedLyrics": "Zapisz edytowany tekst",
+    "copyLyrics": "Kopiuj tekst",
+    "saveLyricsToSong": "Zapisz tekst do utworu",
+    "saveLyricsNotSupported": "Nora aktualnie nie wspiera zapisu tekstu do utworów w formacie '{{format}}'.",
+    "saveLyricsFormatInfo": "* Teksty są zapisywane w formacie <Hyperlink>LRC</Hyperlink>.",
+    "readAboutLrcFormat": "Przezytaj więcej o formacie LRC"
+  },
+
+  "lyricsEditorSettingsPrompt": {
+    "lyricsEditorSettings": "Ustawienia edytora tekstu",
+    "editNextAndCurrentStartAndEndTagsAutomaticallyDescription": "Automatycznie zmieniaj znacznik czasu rozpoczęcia następnej linii tekstu, gdy edytujesz znacznik zakończenia bieżącej linii (i odwrotnie).",
+    "editNextAndCurrentStartAndEndTagsAutomatically": "Automatycznie edytuj znacznik startu następnej linii wraz z końcem bieżącej (i odwrotnie).",
+    "lyricOffsetInputDescription": "Wybierz ujemne lub dodatnie przesunięcie, które zostanie dodane do linii tekstu podczas ich automatycznej edycji.",
+    "lyricOffsetInput": "Przesunięcie (+ lub -)"
+  },
+
+  "pageFocusPrompt": { "pageNotFocused": "Brak fokusu na stronie." },
+
+  "releaseNotesPrompt": {
+    "latestVersion": "Masz najnowszą wersję.",
+    "oldVersion": "<br/><span>Nie masz najnowszej wersji.</span> <Hyperlink>Aktualizuj teraz</Hyperlink>",
+    "outdatedChangelogNotice": "Możesz oglądać przestarzały dziennik zmian.",
+    "versionCheckError": "<br/><span>Nie udało się sprawdzić aktualizacji. Coś jest nie tak po naszej stronie.<div>$t(releaseNotesPrompt.outdatedChangelogNotice)</div></span>",
+    "versionCheckNetworkError": "<br/><span> Nie udało się sprawdzić aktualizacji. Sprawdź swoje połączenie z internetem i spróbuj ponownie.<div>$t(releaseNotesPrompt.outdatedChangelogNotice)</div></span>",
+    "noraReleases": "Wydania Nory",
+    "changelog": "Dziennik zmian",
+    "doNotRemindThisVersionUpdate": "Nie przypominaj mi więcej o tej wersji.",
+    "current": "Obecna",
+    "latest": "Najnowsza",
+    "newFeaturesAndUpdates": "Nowości i aktualizacje",
+    "fixesAndImprovements": "Poprawki i ulepszenia",
+    "issuesAndBugs": "Znane problemy i bugi",
+    "developerUpdates": "Wieści od dewelopera"
+  },
+
+  "appShortcutsPrompt": {
+    "inAppShortcuts": "Skróty w aplikacji",
+
+    "mediaPlayback": "Odtwarzanie",
+    "playPause": "Odtwórz / Pauza",
+    "toggleMute": "Przełącz wyciszenie",
+    "nextSong": "Następny utwór",
+    "prevSong": "Poprzedni utwór",
+    "tenSecondsForward": "10 sekund do przodu",
+    "tenSecondsBackward": "10 sekund do tyłu",
+    "upVolume": "zwiększ głośność",
+    "downVolume": "zmniejsz głośność",
+    "toggleShuffle": "Przełącz losowanie kolejki",
+    "toggleRepeat": "Przełącz powtarzanie kolejki",
+    "toggleFavorite": "Przełącz ulubione",
+    "upPlaybackRate": "Zwiększ prędkość odtwarzania o 0.05x",
+    "downPlaybackRate": "Zmniejsz prędkość odtwarzania o 0.05x",
+    "resetPlaybackRate": "Zresetuj prędkość odtwarzania do 1x",
+
+    "navigation": "Nawigacja",
+    "goHome": "Strona główna",
+    "goBack": "Wstecz",
+    "goForward": "Dalej",
+    "openMiniPlayer": "Otwórz Mini Odtwarzacz",
+    "goToLyrics": "Idź do tekstu utworu",
+    "goToQueue": "Idź do bieżącej kolejki",
+    "goToSearch": "Idź do szukania",
+
+    "selections": "Zaznaczanie",
+    "selectMultipleItems": "Zaznacz wiele",
+
+    "lyrics": "Tekst",
+    "playNextLyricsLine": "Odtwórz następną linię tekstu",
+    "playPrevLyricsLine": "Odtwórz poprzednią linię tekstu",
+
+    "lyricsEditor": "Edytor tekstu",
+    "selectNextLyricsLine": "Zaznacz następną linię tekstu",
+    "selectPrevLyricsLine": "Zaznacz poprzednią linię tekstu",
+    "selectCustomLyricsLine": "Zaznacz własną linię tektsu",
+
+    "otherShortcuts": "Inne skróty",
+    "toggleTheme": "Przełącz motyw aplikacji",
+    "toggleMiniPlayerAlwaysOnTop": "Przełącz bycie Mini Odtwarzacza zawsze na wierzchu",
+    "reload": "Załaduj od nowa",
+    "openDevtools": "Otwórz DevTools",
+    "openAppShortcutsPrompt": "Otwórz podpowiedzi skrótów aplikacji",
+
+    "enterKey": "Enter",
+    "spaceKey": "Spacja",
+    "ctrlKey": "Ctrl",
+    "shiftKey": "Shift",
+    "altKey": "Alt",
+    "homeKey": "Home",
+    "rightArrowKey": "Strzałka w prawo",
+    "leftArrowKey": "Strzałka w lewo",
+    "upArrowKey": "Strzałka w górę",
+    "downArrowKey": "Strzałka w dół",
+
+    "mouseClick": "Kliknięcie myszy",
+    "doubleClick": "Podwójne kliknięcie myszy"
+  },
+
+  "clearLocalStoragePrompt": {
+    "title": "Potwierdź wyczyszczenie lokalnych danych na dysku",
+    "description": "Ten proces usunie wszelkie uszkodzone dane pamięci lokalnej w aplikacji Nora i przywróci ją do ustawień domyślnych.",
+    "effect": "<p>Wykonanie tej akcji wpłynie na następujące dane: </p><ul><li>Większość ustawień preferencji w aplikacji Nora</li><li>Ustawienia odtwarzania, takie jak obecnie grany utwór, głośność itp.</li><li>Dane bieżącej kolejki</li><li>Dane ignorowanych sugestii, takich jak artyści gościnni, oddzielni wykonawcy i duplikaty</li><li>Dane sortowania stron</li><li>Dane korektora graficznego</li><li>Ustawienia edytora tekstu</li></ul>",
+    "restartNotice": "Po zakończeniu procesu aplikacja Nora uruchomi się ponownie."
+  },
+
+  "musixmatchDisclaimerPrompt": {
+    "title": "Zastrzeżenie – teksty Musixmatch",
+    "message": "<li>Teksty Musixmatch są dodane do tego oprogramowania jako funkcja testowa i mogą zostać usunięte w dowolnym momencie.</li><li>Nora nie jest w żaden sposób powiązana z Musixmatch Lyrics ani żadną z jego firm stowarzyszonych lub spółek zależnych, nie jest też przez nie autoryzowana, utrzymywana, sponsorowana ani popierana.</li><li>Opiekunowie tej aplikacji apelują do użytkowników o osobistą odpowiedzialność i korzystanie z tej funkcji w uczciwy sposób, zgodnie z jej przeznaczeniem oraz z poszanowaniem praw autorskich stosowanych przez Musixmatch Lyrics.</li>",
+    "implementationNotice": "Implementacja na podstawie <Hyperlink/> autorstwa Fashni.",
+    "hyperlinkTitle": "Repozytorium GitHub MxLRC",
+    "contactAboutComplaints": "Jeśli masz jakiekolwiek skargi/zażalenia, możesz skontaktować się ze mną przez serwer Discord Nora albo przez mój <Hyperlink>email</Hyperlink>."
+  },
+
+  "musixmatchSettingsPrompt": {
+    "title": "Ustawienia Musixmatch",
+    "message": "<li>Musixmatch wymaga tokenu użytkownika do poprawnego działania.</li><li>Musixmatch może czasem nie wyświetlać tekstów z powodu długotrwałego korzystania z usługi na tym samym tokenie.</li><li>Skorzystaj z poradnika na <Hyperlink>Wiki Spicetify</Hyperlink>, aby uzyskać nowy token Musixmatch.</li>",
+    "showToken": "Pokaż token",
+    "hideToken": "Ukryj token",
+    "updateToken": "Zaktualizuj token",
+    "tokenUpdateSuccess": "Pomyślnie zaktualizowano token.",
+    "tokenUpdateFailed": "Nie udało się zaktualizować tokenu.",
+    "tokenMissingCharacters": "TOKEN powinien być ciągiem 54 znaków. (Wymagane jeszcze: {{count}}).",
+    "tokenIncorrectCharacters": "TOKEN powinien zawierać tylko znaki alfanumeryczne.",
+    "savedTokenAvailableMessage": "<Title><span/> Zapisany token jest dostępny.</Title><p> W aplikacji Nora dostępny jest już ważny token Musixmatch zapisany przez użytkownika.</p> <p> Musisz zmieniać token tylko wtedy, gdy usługa nie działa poprawnie.</p>"
+  },
+
+  "customizeSelectedMetadataPrompt": {
+    "selected": "Wybrano",
+    "select": "Wybierz",
+    "title": "Dostosuj pobrane metadane dla `{{title}}`",
+    "selectArtwork": "Wybierz okładkę",
+    "noArtworksFound": "Brak okładek",
+    "customizeOtherMetadata": "Inne metadane",
+    "syncedLyricsAvailable": "Dostępny tekst zsynchronizowany",
+    "unsyncedLyricsAvailable": "Dostępny tekst",
+    "addOnlySelected": "Dodaj wybrane",
+    "addAll": "Dodaj wszystkie"
+  },
+
+  "resetTagsToDefaultPrompt": {
+    "changed": "Zmieniono",
+    "title": "Potwierdź resetowanie danych utworu do domyślnych",
+    "description": "Jesteś pewny(a), że chcesz zresetować dane utworu? Stracisz dane, które edytowałeś(aś) na tym ekranie.",
+    "resetToDefault": "Przywróć domyślne"
+  },
+
+  "songMetadataResultSelectPrompt": {
+    "title": "Wyniki dla <span/>"
+  },
+
+  "errorPrompt": {
+    "title": "Wystąpił błąd",
+    "sendErrorInfo": "Prześlij nam <Hyperlink1>opinię</Hyperlink1>, aby ulepszyć aplikację, lub <Hyperlink2>zgłoś problem</Hyperlink2> na GitHubie."
+  },
+
+  "openLinkConfirmPrompt": {
+    "description": "Próbujesz otworzyć link, który przekieruje Cię do <span/>.<br/> Ten link zostanie otwarty w Twojej domyślnej przeglądarce.",
+    "doNotVerifyLink": "Nie weryfikuj przy próbie otwarcia linku.",
+    "openLink": "Otwórz link"
+  },
+
+  "songUnplayableErrorPrompt": {
+    "title": "Nie można odtworzyć utworu",
+    "description": "Wygląda na to, że nie możemy odtworzyć tego utworu. Sprawdź, czy wybrany utwór jest dostępny w systemie i czy aplikacja ma do niego dostęp."
+  },
+
+  "unsupportedFileMessagePrompt": {
+    "title": "Nieobsługiwany plik audio",
+    "description": "Próbujesz otworzyć plik z rozszerzeniem <span/>, które nie jest obsługiwane przez tę aplikację.<br/> Obecnie obsługujemy tylko następujące formaty audio. <div/>"
+  },
+
+  "duplicateArtistsSuggestion": {
+    "message": "<div><p>Czy <span/> to ten sam wykonawca?</p><p>Jeśli tak, możesz połączyć ich treści w jednego wykonawcę lub zignorować tę sugestię.</p></div>",
+    "linkToArtist": "Połącz z {{name}}"
+  },
+
+  "separateArtistsSuggestion": {
+    "message": "<div><p>Czy <span/> to {{count}} osobnych artystów?</p><p>Jeśli tak, możesz ich zorganizować, zaznaczając jako osobnych wykonawców, lub zignorować tę sugestię.</p></div>",
+    "separateAsArtists": "Rozdziel jako {{count}} artystów"
+  },
+
+  "featArtistsSuggestion": {
+    "message_one": "<p>Czy <span/> to artysta gościnny w tym utworze?</p><p>Jeśli tak, możesz dodać go jako wykonawcę tego utworu lub zignorować tę sugestię.</p>",
+    "message_other": "<p>Czy <span/> to {{count}} artystów gościnnych w tym utworze?</p><p>Jeśli tak, możesz dodać ich jako wykonawców tego utworu lub zignorować tę sugestię.</p>",
+    "featArtistsTitleReset": "Usuń informacje o artystach gościnnych z tytułu utworu po dodaniu ich do listy wykonawców.",
+    "addArtistsToSong": "Dodaj $t(common.artistWithCount, {\"count\":{{count}}}) do utworu",
+    "editInMetadataEditingPage": "Edytuj na stronie edycji metadanych",
+    "modificationNotice": "Pamiętaj, że dodanie artystów gościnnych do utworu zaktualizuje zarówno dane w bibliotece, jak i metadane pliku."
+  },
+
+  "biography": {
+    "readMore": "Czytaj więcej...",
+    "readMoreInLastFm": "Czytaj więcej na LastFM",
+    "aboutName": "O <span/>",
+    "goToTagInLastFm": "Przejdź do tagu {{name}} na LastFM"
+  },
+
+  "notifications": {
+    "clearAll": "Wyczyść wszystko",
+    "playingNext": "`{{title}}` będzie grane jako następne.",
+    "songBlacklisted": "`{{title}}` jest wykluczony.",
+    "playingNextSongsWithCount": "$t(common.songWithCount, {\"count\":{{count}}}) będzie grane jako następne.",
+    "addedToQueue": "Dodano $t(common.songWithCount, {\"count\":{{count}}}) do kolejki",
+    "suggestionIgnored": "Sugestia zignorowana.",
+    "songRestoreSuccess": "Utwór przywrócony pomyślnie.",
+    "songDataUpdateFailed": "Błąd aktualizacji danych utworu.",
+    "noSongDataEdits": "Nie zmieniłeś(aś) żadnych danych utworu.",
+    "selectASongToPlay": "Wybierz utwór do odtwarzania",
+    "alreadyInPage": "Jesteś już na tej stronie.",
+    "playbackRateChanged": "Zmieniono prędkość odtwarzania na {{val}}x",
+    "playbackRateReset": "Zresetowano prędkosć odtwarzania do 1x",
+    "playbackPausedDueToSongDeletion": "Odtwarzanie zostało zatrzymane, ponieważ aktualny utwór został usunięty.",
+    "languageChanged": "Zmieniono pomyślnie język aplikacji."
+  },
+
+  "backend": {
+    "RESYNC_SUCCESSFUL": "Ponowna synchronizacja biblioteki ukończona pomyślnie.",
+    "RESET_SUCCESSFUL": "Zresetowano aplikację, trwa ponowne uruchamianie.",
+    "RESET_FAILED": "Reset aplikacji nie podiódł się. Ponowne ładowanie aplikacji.",
+    "APP_THEME_CHANGE": "Motyw systemowy zmieniony na {{theme}}",
+    "SONG_REMOVE_PROCESS_UPDATE": "Usunięto {{value}} z {{total}} utworów.",
+    "OPEN_SONG_IN_EXPLORER_FAILED": "Otwarcie pliku utworu w eksploratorze nie powiodło się, ponieważ nie znaleziono utworu w bibliotece.",
+    "PENDING_METADATA_UPDATES_SAVED": "Pomyślnie zapisano oczekujące aktualizacje metadanych dla `{{title}}`.",
+    "METADATA_UPDATE_FAILED": "Aktualizacja metadanych nie powiodła się. {{message}}",
+    "SONG_EXT_NOT_SUPPORTED_FOR_LYRICS_SAVES": "Nie można zapisać tekstu, ponieważ rozszerzenie bieżącego utworu ({{ext}}) nie obsługuje modyfikacji metadanych.",
+    "LASTFM_LOGIN_SUCCESS": "Pomyślnie zalogowano do LastFM.",
+    "AUDIO_PARSING_PROCESS_UPDATE": "Przetworzono {{value}} z {{total}} utworów.",
+    "SONG_PALETTE_GENERATING_PROCESS_UPDATE": "Generowanie palet kolorów dla {{value}} z {{total}} utworów.",
+    "GENRE_PALETTE_GENERATING_PROCESS_UPDATE": "Generowanie palet kolorów dla {{value}} z {{total}} gatunków.",
+    "LYRICS_FIND_FAILED": "Nie znaleziono tekstu dla `{{title}}`",
+    "LYRICS_TRANSLATION_SUCCESS": "Tekst przetłumaczony pomyślnie",
+    "LYRICS_CONVERT_SUCCESS": "Tekst przekonwertowany pomyślnie",
+    "RESET_CONVERTED_LYRICS_SUCCESS": "Pomyślnie zresetowano tekst",
+    "LYRICS_TRANSLATION_FAILED": "Nie udało się przetłumaczyć tekstu",
+    "LYRICS_TRANSLATION_TO_SAME_SOURCE_LANGUAGE": "Zażądano tłumaczenia tekstu na ten sam język źródłowy '{{language}}'",
+    "LYRICS_CONVERT_FAILED": "Nie udało się przekonwertować tekstu",
+    "RESET_CONVERTED_LYRICS_FAILED": "Nie udało się zresetować tekstu",
+    "MUSIC_FOLDER_DELETED": "Folder `{{name}}` został usunięty z systemu. $t(common.songWithCount, {\"count\":{{count}}}) powiązane z tym folderem zostaną usunięte z biblioteki.",
+    "EMPTY_MUSIC_FOLDER_DELETED": "Folder `{{name}}` został usunięty z systemu. Nie znaleziono utworów powiązanych z tym folderem. Biblioteka pozostanie bez zmian.",
+    "WHITELISTING_FOLDER_FAILED_DUE_TO_BLACKLISTED_PARENT_FOLDER": "Nie można oznaczyć folderu `{{folderName}}` jako dopuszczony, ponieważ jego folder nadrzędny '{{parentFolderName}}' jest wykluczony. Oznacz folder nadrzędny jako dopuszczony, aby odblokować ten folder.",
+    "WHITELISTING_SONG_FAILED_DUE_TO_BLACKLISTED_DIRECTORY": "Nie można oznaczyć utworu '{{songName}}' jako dopuszczony, ponieważ jego katalog '{{directoryName}}' jest wykluczony. Oznacz ten katalog jako dopuszczony, aby odblokować ten utwór.",
+    "SONG_WHITELISTED": "$t(common.songWithCount, {\"count\":{{count}}}) usunięto z wykluczonych.",
+    "ARTWORK_SAVED": "Zapisano okładkę w wybranej lokalizacji.",
+    "DESTINATION_NOT_SELECTED": "Nie wybrano miejsca zapisu.",
+    "ARTWORK_SAVE_FAILED": "Nie udało się zapisać okładki.",
+    "PLAYBACK_FROM_UNKNOWN_SOURCE": "Odtwarzasz utwór spoza Twojej biblioteki.",
+    "ARTIST_DISLIKE": "Artysta `{{name}}` został usunięty z ulubionych.",
+    "ARTIST_LIKE": "Artysta `{{name}}` został dodany do ulubionych.",
+    "SONG_DISLIKE": "Utwór `{{name}}` został usunięty z ulubionych.",
+    "SONG_LIKE": "Utwór `{{name}}` został dodany do ulubionych.",
+    "SONG_DELETED": "Utwór `{{name}}` został usunięty z systemu.",
+    "FOLDER_PARSED_FOR_DIRECTORIES": "Znaleziono $t(folder.directoryCount, {\"count\":{{count}}}) w $t(folder.selectedFolderCount, {\"count\":{{folderCount}}}).",
+    "NO_MORE_SONG_PALETTES": "Brak kolejnych palet utworów do wygenerowania.",
+    "NO_MORE_GENRE_PALETTES": "Brak kolejnych palet gatunków do wygenerowania.",
+    "PARSE_FAILED": "Błąd `{{name}}` podczas próby dodania utworu do biblioteki. Przejdź do ustawień, aby ponownie zsynchronizować bibliotekę.",
+    "PARSE_SUCCESSFUL": "Utwór `{{name}}` dodano do biblioteki.",
+    "LYRICS_SAVE_QUEUED": "Tekst dla `{{title}}` zostanie zapisany automatycznie.",
+    "LYRICS_SAVED_IN_LRC_FILE": "Tekst dla tego utworu z rozszerzeniem '{{ext}}' zostanie zapisany w pliku LRC.",
+    "PENDING_LYRICS_SAVED": "Pomyślnie zapisano oczekujące teksty dla `{{title}}`.",
+    "ADDED_SONGS_TO_PLAYLIST": "Pomyślnie dodano $t(common.songWithCount, {\"count\":{{count}}}) do `{{name}}`.",
+    "APPDATA_IMPORT_STARTED": "Rozpoczęto importowanie danych aplikacji. Proszę czekać...",
+    "APPDATA_IMPORT_SUCCESS": "Pomyślnie zaimportowano dane aplikacji.",
+    "APPDATA_IMPORT_SUCCESS_WITH_PENDING_RESTART": "$t(backend.APPDATA_IMPORT_SUCCESS) Aplikacja zostanie zrestartowana za 5 sekund.",
+    "APPDATA_IMPORT_FAILED": "Nie udało się zaimportować danych aplikacji.",
+    "APPDATA_IMPORT_FAILED_DUE_TO_MISSING_FILES": "$t(backend.APPDATA_IMPORT_FAILED) W wybranym folderze brakuje wymaganych plików.",
+    "APPDATA_EXPORT_STARTED": "Rozpoczęto eksportowanie danych aplikacji. Proszę czekać...",
+    "APPDATA_EXPORT_SUCCESS": "Pomyślnie wyeksportowano dane aplikacji.",
+    "APPDATA_EXPORT_FAILED": "Wystąpił błąd podczas eksportowania danych aplikacji.",
+    "PLAYLIST_EXPORT_SUCCESS": "Pomyślnie wyeksportowano playlistę `{{name}}`.",
+    "PLAYLIST_EXPORT_FAILED": "Wystąpił błąd podczas eksportowania playlisty `{{name}}`.",
+    "PLAYLIST_IMPORT_SUCCESS": "Pomyślnie zaimportowano playlistę `{{name}}`.",
+    "PLAYLIST_IMPORT_FAILED": "Nie udało się zaimportować playlisty.",
+    "PLAYLIST_IMPORT_FAILED_DUE_TO_SONGS_OUTSIDE_LIBRARY": "Podczas importu playlisty znaleziono $t(common.songWithCount, {\"count\":{{count}}}) spoza biblioteki, co nie jest obsługiwane.",
+    "PLAYLIST_IMPORT_FAILED_DUE_TO_INVALID_FILE_DATA": "Nie udało się zaimportować playlisty, ponieważ wybrano plik z nieprawidłowymi danymi.",
+    "PLAYLIST_IMPORT_FAILED_DUE_TO_INVALID_FILE_EXTENSION": "Import playlisty nie powiódł się, ponieważ wybrany plik nie miał rozszerzenia '.m3u8'.",
+    "PLAYLIST_IMPORT_TO_EXISTING_PLAYLIST": "Zaimportowano $t(common.songWithCount, {\"count\":{{count}}}) do istniejącej playlisty `{{name}}`.",
+    "PLAYLIST_IMPORT_TO_EXISTING_PLAYLIST_FAILED": "Wystąpił błąd podczas importowania utworów do istniejącej playlisty.",
+    "PLAYLIST_CREATION_FAILED": "Nie udało się utworzyć playlisty.",
+    "PLAYLIST_RENAME_SUCCESS": "Zmieniono nazwę playlisty pomyślnie.",
+    "PLAYLIST_NOT_FOUND": "Nie znaleziono playlisty.",
+    "SONG_REPARSE_SUCCESS": "Pomyślnie przetworzono ponownie `{{title}}`.",
+    "SONG_REPARSE_FAILED": "Wystąpił błąd podczas ponownego przetwarzania utworu."
+  },
+
+  "discordrpc": {
+    "noraOnGitHub": "Nora na GitHubie",
+    "untitledSong": "Utwór bez tytułu",
+    "unknownArtist": "nieznany wykonawca",
+    "playingASong": "Słucha utworu"
+  }
 }

--- a/src/renderer/src/components/SettingsPage/Settings/StartupSettings.tsx
+++ b/src/renderer/src/components/SettingsPage/Settings/StartupSettings.tsx
@@ -26,6 +26,14 @@ const StartupSettings = () => {
     }
   });
 
+  const { mutate: updateTraySingleClickBehavior } = useMutation({
+    mutationFn: (enable: boolean) =>
+      window.api.settings.updateTraySingleClickBehavior(enable),
+    onSettled: () => {
+      queryClient.invalidateQueries(settingsQuery.all);
+    }
+  });
+
   return (
     <li className="main-container startup-settings-container mb-16" id="startup-settings-container">
       <div className="title-container text-font-color-highlight dark:text-dark-font-color-highlight mt-1 mb-4 flex items-center text-2xl font-medium">
@@ -72,6 +80,15 @@ const StartupSettings = () => {
             isChecked={userSettings ? userSettings.hideWindowOnClose : false}
             checkedStateUpdateFunction={(state) => updateHideWindowOnCloseState(state)}
             labelContent={t('settingsPage.hideWindowOnClose')}
+          />
+        </li>
+        <li className="tray-click-behavior-checkbox-container mt-4">
+          <div className="description">{t('settingsPage.trayClickBehaviorDescription')}</div>
+          <Checkbox
+            id="trayClickBehavior"
+            isChecked={userSettings ? userSettings.traySingleClickTogglesWindow : false}
+            checkedStateUpdateFunction={(state) => updateTraySingleClickBehavior(state)}
+            labelContent={t('settingsPage.traySingleClickTogglesWindow')}
           />
         </li>
       </ul>

--- a/src/renderer/src/other/appReducer.tsx
+++ b/src/renderer/src/other/appReducer.tsx
@@ -605,6 +605,7 @@ export const USER_DATA_TEMPLATE: UserData = {
   isMiniPlayerAlwaysOnTop: false,
   isMusixmatchLyricsEnabled: false,
   hideWindowOnClose: false,
+  traySingleClickTogglesWindow: false,
   openWindowAsHiddenOnSystemStart: false,
   openWindowMaximizedOnStart: false,
   sendSongScrobblingDataToLastFM: false,

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -60,6 +60,7 @@ declare global {
     | 'app/dataUpdateEvent'
     | 'app/toggleMiniPlayer'
     | 'app/toggleAutoLaunch'
+    | 'app/updateTraySingleClickBehavior'
     | 'app/getFolderData'
     | 'app/restartRenderer'
     | 'app/restartApp'
@@ -419,6 +420,7 @@ declare global {
     isMiniPlayerAlwaysOnTop: boolean;
     isMusixmatchLyricsEnabled: boolean;
     hideWindowOnClose: boolean;
+    traySingleClickTogglesWindow: boolean;
     sendSongScrobblingDataToLastFM: boolean;
     sendSongFavoritesDataToLastFM: boolean;
     sendNowPlayingSongDataToLastFM: boolean;


### PR DESCRIPTION
adds \	raySingleClickTogglesWindow\ setting (default false). when enabled, single-click toggles main window instead of opening menu. hot-swappable via IPC — no restart needed.

- new column \	ray_single_click_toggles_window\ on \user_settings\
- setting checkbox under startup settings
- double-click handler only registered when setting is off (avoids 3x toggle on double-click)
- runtime toggle wired through same pattern as \	oggleMiniPlayerAlwaysOnTop\
- en/pl locale strings

pr on fork: Owie6789/Nora-quickfixes#3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a startup setting to choose whether a single system tray click toggles window visibility.
  * When disabled, a single click opens the tray menu and a double-click toggles the window.
  * The preference is saved and applied immediately.

* **Documentation**
  * Updated English and Polish localization files for formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->