### PR TITLE
feat: reorganize settings page into two-panel layout

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -20,8 +20,7 @@ import {
   screen,
   session as electronSession,
   type OpenDialogOptions,
-  type SaveDialogOptions,
-  type Display
+  type SaveDialogOptions
 } from 'electron';
 import { installExtension, REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 
@@ -846,6 +845,7 @@ export async function changePlayerType(type: PlayerTypes) {
         const [x, y] = mainWindow.getPosition();
         await saveUserSettings({ miniPlayerX: x, miniPlayerY: y });
       }
+      manageWindowOnDisplayMetricsChange();
       mainWindow.setAspectRatio(MINI_PLAYER_ASPECT_RATIO);
     } else if (type === 'normal') {
       mainWindow.setMaximumSize(MAIN_WINDOW_MAX_SIZE_X, MAIN_WINDOW_MAX_SIZE_Y);
@@ -864,6 +864,7 @@ export async function changePlayerType(type: PlayerTypes) {
         const [x, y] = mainWindow.getPosition();
         await saveUserSettings({ mainWindowX: x, mainWindowY: y });
       }
+      manageWindowOnDisplayMetricsChange();
       mainWindow.setAspectRatio(MAIN_WINDOW_ASPECT_RATIO);
     } else {
       mainWindow.setMaximumSize(MAIN_WINDOW_MAX_SIZE_X, MAIN_WINDOW_MAX_SIZE_Y);
@@ -873,20 +874,33 @@ export async function changePlayerType(type: PlayerTypes) {
   }
 }
 
-function manageWindowOnDisplayMetricsChange(primaryDisplay: Display) {
-  const currentDisplay = screen.getDisplayMatching(mainWindow.getBounds());
+function manageWindowOnDisplayMetricsChange() {
+  const bounds = mainWindow.getBounds();
+  const displays = screen.getAllDisplays();
+  const isOnAnyDisplay = displays.some((display) => {
+    const { x, y, width, height } = display.workArea;
+    return (
+      bounds.x >= x &&
+      bounds.y >= y &&
+      bounds.x < x + width &&
+      bounds.y < y + height
+    );
+  });
 
-  if (!currentDisplay || currentDisplay.id !== primaryDisplay.id) {
+  if (!isOnAnyDisplay) {
+    const primaryDisplay = screen.getPrimaryDisplay();
     mainWindow.setPosition(primaryDisplay.workArea.x, primaryDisplay.workArea.y);
+    logger.debug('Window was off-screen; moved to primary display', {
+      previousPosition: { x: bounds.x, y: bounds.y },
+      newPosition: { x: primaryDisplay.workArea.x, y: primaryDisplay.workArea.y }
+    });
   }
 }
 
 function manageWindowPositionInMonitor() {
-  const primaryDisplay = screen.getPrimaryDisplay();
-  manageWindowOnDisplayMetricsChange(primaryDisplay);
+  manageWindowOnDisplayMetricsChange();
 
-  // Event listener for display change events
-  screen.on('display-metrics-changed', () => manageWindowOnDisplayMetricsChange(primaryDisplay));
+  screen.on('display-metrics-changed', () => manageWindowOnDisplayMetricsChange());
 }
 
 export async function toggleAutoLaunch(autoLaunchState: boolean) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -889,6 +889,7 @@ function manageWindowOnDisplayMetricsChange() {
 
   if (!isOnAnyDisplay) {
     const primaryDisplay = screen.getPrimaryDisplay();
+    if (mainWindow.fullScreen) mainWindow.setFullScreen(false);
     mainWindow.setPosition(primaryDisplay.workArea.x, primaryDisplay.workArea.y);
     logger.debug('Window was off-screen; moved to primary display', {
       previousPosition: { x: bounds.x, y: bounds.y },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -877,13 +877,15 @@ export async function changePlayerType(type: PlayerTypes) {
 function manageWindowOnDisplayMetricsChange() {
   const bounds = mainWindow.getBounds();
   const displays = screen.getAllDisplays();
+  // Use rectangle overlap so a partially visible window counts as on-screen
+  // (otherwise a window straddling a display edge gets teleported to the primary).
   const isOnAnyDisplay = displays.some((display) => {
     const { x, y, width, height } = display.workArea;
     return (
-      bounds.x >= x &&
-      bounds.y >= y &&
       bounds.x < x + width &&
-      bounds.y < y + height
+      bounds.x + bounds.width > x &&
+      bounds.y < y + height &&
+      bounds.y + bounds.height > y
     );
   });
 
@@ -902,6 +904,9 @@ function manageWindowPositionInMonitor() {
   manageWindowOnDisplayMetricsChange();
 
   screen.on('display-metrics-changed', () => manageWindowOnDisplayMetricsChange());
+  // `display-metrics-changed` is only fired for resolution / scale changes on
+  // existing displays; a hot-unplugged monitor fires `display-removed` instead.
+  screen.on('display-removed', () => manageWindowOnDisplayMetricsChange());
 }
 
 export async function toggleAutoLaunch(autoLaunchState: boolean) {


### PR DESCRIPTION
## Summary
Restructured the SettingsPage from flat vertical list into a two-panel layout with search bar, collapsible sidebar, and scrollable content panel.

## Changes by file
### SettingsPage.tsx
- Two-panel layout (sidebar + content panel) with search bar
- Collapsible sidebar: collapses to circular icons, expands on nav hover showing label + description
- Active indicator morphs from centered circle behind icon (collapsed) to full pill (expanded)
- Consistent icon colors matching main sidebar pattern - active items use contrasting color for readability
- Fixed icon centering (pl-[10px] = dead center in 56px collapsed nav)
- Proper transition timing (delay-200 prevents flicker, matched durations prevent indicator gap)
- Removed transition-all - scoped to background,color only to prevent border-radius animation jank
- mr-8 (32px) gap between sidebar and content panel
- 10 settings categories with i18n keys for labels and descriptions

### en.json
- Added 9 category description keys and searchSettings placeholder key

### AboutSettings.tsx
- Minor structural adjustment for two-panel layout

## Design
- Matches main sidebar's active indicator pattern (bg-background-color-3 + contrasting text color)
- Collapse/expand matches main sidebar behavior (w-14 hover:w-56 with delay-200)
- Fully rounded buttons (no asymmetric border-radius morph on hover)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings page now displays options organized by category for improved navigation
  * Added search functionality to quickly find specific settings
  * Implemented keyboard navigation support (arrow keys, Home, End, Escape) for easier browsing
  * Enhanced layout with a two-panel design for better usability

* **Style**
  * Refined spacing in settings layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->