### PR TITLE
fix(#457): persist sort-by preference across navigation for detail pages

### DIFF
--- a/src/renderer/src/other/appReducer.tsx
+++ b/src/renderer/src/other/appReducer.tsx
@@ -419,7 +419,11 @@ export const LOCAL_STORAGE_DEFAULT_TEMPLATE: LocalStorage = {
     genresPage: 'aToZ',
     playlistsPage: 'aToZ',
     songsPage: 'aToZ',
-    musicFoldersPage: 'aToZ'
+    musicFoldersPage: 'aToZ',
+    playlistDetailPage: 'addedOrder',
+    albumDetailPage: 'trackNoDescending',
+    genreDetailPage: 'aToZ',
+    artistDetailPage: 'aToZ'
   },
   equalizerPreset: {
     thirtyTwoHertzFilter: 0,

--- a/src/renderer/src/routes/main-player/albums/$albumId.tsx
+++ b/src/renderer/src/routes/main-player/albums/$albumId.tsx
@@ -15,7 +15,8 @@ import { songSearchSchema } from '@renderer/utils/zod/songSchema';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import { useCallback, useContext } from 'react';
+import storage from '@renderer/utils/localStorage';
+import { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export const Route = createFileRoute('/main-player/albums/$albumId')({
@@ -30,7 +31,11 @@ function AlbumInfoPage() {
   const { albumId } = Route.useParams({
     select: (params) => ({ albumId: Number(params.albumId) })
   });
-  const { scrollTopOffset, sortingOrder = 'trackNoDescending' } = Route.useSearch();
+  const albumDetailSortingState = useStore(
+    store,
+    (state) => state.localStorage.sortingStates?.albumDetailPage || 'trackNoDescending'
+  );
+  const { scrollTopOffset, sortingOrder = albumDetailSortingState } = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
 
   const preferences = useStore(store, (state) => state?.localStorage?.preferences);
@@ -39,6 +44,10 @@ function AlbumInfoPage() {
   const { createQueue, updateQueueData, addNewNotifications, playSong } =
     useContext(AppUpdateContext);
   const { t } = useTranslation();
+
+  useEffect(() => {
+    storage.sortingStates.setSortingStates('albumDetailPage', sortingOrder);
+  }, [sortingOrder]);
 
   const { data: albumData } = useSuspenseQuery({
     ...albumQuery.single({ albumId: albumId }),

--- a/src/renderer/src/routes/main-player/albums/$albumId.tsx
+++ b/src/renderer/src/routes/main-player/albums/$albumId.tsx
@@ -12,10 +12,10 @@ import { albumQuery } from '@renderer/queries/albums';
 import { songQuery } from '@renderer/queries/songs';
 import { store } from '@renderer/store/store';
 import { songSearchSchema } from '@renderer/utils/zod/songSchema';
+import storage from '@renderer/utils/localStorage';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import storage from '@renderer/utils/localStorage';
 import { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/renderer/src/routes/main-player/artists/$artistId.tsx
+++ b/src/renderer/src/routes/main-player/artists/$artistId.tsx
@@ -17,15 +17,17 @@ import { albumQuery } from '@renderer/queries/albums';
 import { artistQuery } from '@renderer/queries/aritsts';
 import { songQuery } from '@renderer/queries/songs';
 import { store } from '@renderer/store/store';
+import { songSearchSchema } from '@renderer/utils/zod/songSchema';
 import calculateTimeFromSeconds from '@renderer/utils/calculateTimeFromSeconds';
 import { useSuspenseQuery, useMutation, useQuery } from '@tanstack/react-query';
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import storage from '@renderer/utils/localStorage';
 import { useTranslation } from 'react-i18next';
 
 export const Route = createFileRoute('/main-player/artists/$artistId')({
+  validateSearch: songSearchSchema,
   component: ArtistInfoPage,
   loader: async (route) => {
     const artistId = Number(route.params.artistId);
@@ -61,7 +63,8 @@ function ArtistInfoPage() {
     store,
     (state) => state.localStorage.sortingStates?.artistDetailPage || 'aToZ'
   );
-  const [sortingOrder, setSortingOrder] = useState<SongSortTypes>(artistDetailSortingState);
+  const { sortingOrder = artistDetailSortingState } = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
 
   useEffect(() => {
     storage.sortingStates.setSortingStates('artistDetailPage', sortingOrder);
@@ -538,7 +541,10 @@ function ArtistInfoPage() {
                   name: 'ArtistInfoPageSongsSortDropdown',
                   value: sortingOrder,
                   options: songSortOptions,
-                  onChange: (e) => setSortingOrder(e.currentTarget.value as SongSortTypes)
+                  onChange: (e) => {
+                    const order = e.currentTarget.value as SongSortTypes;
+                    navigate({ search: (prev) => ({ ...prev, sortingOrder: order }) });
+                  }
                 }
               ]}
             />

--- a/src/renderer/src/routes/main-player/artists/$artistId.tsx
+++ b/src/renderer/src/routes/main-player/artists/$artistId.tsx
@@ -17,13 +17,13 @@ import { albumQuery } from '@renderer/queries/albums';
 import { artistQuery } from '@renderer/queries/aritsts';
 import { songQuery } from '@renderer/queries/songs';
 import { store } from '@renderer/store/store';
-import { songSearchSchema } from '@renderer/utils/zod/songSchema';
 import calculateTimeFromSeconds from '@renderer/utils/calculateTimeFromSeconds';
+import storage from '@renderer/utils/localStorage';
+import { songSearchSchema } from '@renderer/utils/zod/songSchema';
 import { useSuspenseQuery, useMutation, useQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import storage from '@renderer/utils/localStorage';
 import { useTranslation } from 'react-i18next';
 
 export const Route = createFileRoute('/main-player/artists/$artistId')({

--- a/src/renderer/src/routes/main-player/artists/$artistId.tsx
+++ b/src/renderer/src/routes/main-player/artists/$artistId.tsx
@@ -21,7 +21,8 @@ import calculateTimeFromSeconds from '@renderer/utils/calculateTimeFromSeconds';
 import { useSuspenseQuery, useMutation, useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import { useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import storage from '@renderer/utils/localStorage';
 import { useTranslation } from 'react-i18next';
 
 export const Route = createFileRoute('/main-player/artists/$artistId')({
@@ -56,7 +57,15 @@ function ArtistInfoPage() {
   });
   const [isAllAlbumsVisible, setIsAllAlbumsVisible] = useState(false);
   const [isAllSongsVisible, setIsAllSongsVisible] = useState(false);
-  const [sortingOrder, setSortingOrder] = useState<SongSortTypes>('aToZ');
+  const artistDetailSortingState = useStore(
+    store,
+    (state) => state.localStorage.sortingStates?.artistDetailPage || 'aToZ'
+  );
+  const [sortingOrder, setSortingOrder] = useState<SongSortTypes>(artistDetailSortingState);
+
+  useEffect(() => {
+    storage.sortingStates.setSortingStates('artistDetailPage', sortingOrder);
+  }, [sortingOrder]);
 
   const songsContainerRef = useRef(null);
   const { width } = useResizeObserver(songsContainerRef);

--- a/src/renderer/src/routes/main-player/genres/$genreId.tsx
+++ b/src/renderer/src/routes/main-player/genres/$genreId.tsx
@@ -14,7 +14,8 @@ import { songSearchSchema } from '@renderer/utils/zod/songSchema';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import { useCallback, useContext } from 'react';
+import storage from '@renderer/utils/localStorage';
+import { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export const Route = createFileRoute('/main-player/genres/$genreId')({
@@ -28,6 +29,10 @@ export const Route = createFileRoute('/main-player/genres/$genreId')({
 function GenreInfoPage() {
   const queue = useStore(store, (state) => state.localStorage.queue);
   const preferences = useStore(store, (state) => state.localStorage.preferences);
+  const genreDetailSortingState = useStore(
+    store,
+    (state) => state.localStorage.sortingStates?.genreDetailPage || 'aToZ'
+  );
 
   const { createQueue, updateQueueData, addNewNotifications, playSong } =
     useContext(AppUpdateContext);
@@ -39,9 +44,13 @@ function GenreInfoPage() {
   });
   const {
     scrollTopOffset,
-    sortingOrder = 'aToZ',
+    sortingOrder = genreDetailSortingState,
     filteringOrder = 'notSelected'
   } = Route.useSearch();
+
+  useEffect(() => {
+    storage.sortingStates.setSortingStates('genreDetailPage', sortingOrder);
+  }, [sortingOrder]);
 
   const { data: genreData } = useSuspenseQuery({
     ...genreQuery.single({ genreId }),

--- a/src/renderer/src/routes/main-player/genres/$genreId.tsx
+++ b/src/renderer/src/routes/main-player/genres/$genreId.tsx
@@ -11,10 +11,10 @@ import { genreQuery } from '@renderer/queries/genres';
 import { songQuery } from '@renderer/queries/songs';
 import { store } from '@renderer/store/store';
 import { songSearchSchema } from '@renderer/utils/zod/songSchema';
+import storage from '@renderer/utils/localStorage';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import storage from '@renderer/utils/localStorage';
 import { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/renderer/src/routes/main-player/playlists/$playlistId.tsx
+++ b/src/renderer/src/routes/main-player/playlists/$playlistId.tsx
@@ -15,7 +15,8 @@ import { songSearchSchema } from '@renderer/utils/zod/songSchema';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import { lazy, useCallback, useContext } from 'react';
+import storage from '@renderer/utils/localStorage';
+import { lazy, useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const SensitiveActionConfirmPrompt = lazy(
@@ -41,7 +42,7 @@ function PlaylistInfoPage() {
   const queue = useStore(store, (state) => state.localStorage.queue);
   const playlistSortingState = useStore(
     store,
-    (state) => state.localStorage.sortingStates?.songsPage || 'addedOrder'
+    (state) => state.localStorage.sortingStates?.playlistDetailPage || 'addedOrder'
   );
   const preferences = useStore(store, (state) => state.localStorage.preferences);
   const { updateQueueData, changePromptMenuData, addNewNotifications, createQueue, playSong } =
@@ -49,6 +50,10 @@ function PlaylistInfoPage() {
   const { t } = useTranslation();
   const { sortingOrder = playlistSortingState, filteringOrder = 'notSelected' } = Route.useSearch();
   const navigate = useNavigate({ from: '/main-player/playlists/$playlistId' });
+
+  useEffect(() => {
+    storage.sortingStates.setSortingStates('playlistDetailPage', sortingOrder);
+  }, [sortingOrder]);
 
   const { data: playlistData } = useSuspenseQuery({
     ...playlistQuery.single({ playlistId: playlistId }),

--- a/src/renderer/src/routes/main-player/playlists/$playlistId.tsx
+++ b/src/renderer/src/routes/main-player/playlists/$playlistId.tsx
@@ -12,10 +12,10 @@ import { playlistQuery } from '@renderer/queries/playlists';
 import { songQuery } from '@renderer/queries/songs';
 import { store } from '@renderer/store/store';
 import { songSearchSchema } from '@renderer/utils/zod/songSchema';
+import storage from '@renderer/utils/localStorage';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import storage from '@renderer/utils/localStorage';
 import { lazy, useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/renderer/src/routes/main-player/playlists/favorites.tsx
+++ b/src/renderer/src/routes/main-player/playlists/favorites.tsx
@@ -10,10 +10,10 @@ import { queryClient } from '@renderer/index';
 import { songQuery } from '@renderer/queries/songs';
 import { store } from '@renderer/store/store';
 import { songSearchSchema } from '@renderer/utils/zod/songSchema';
+import storage from '@renderer/utils/localStorage';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import storage from '@renderer/utils/localStorage';
 import { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/renderer/src/routes/main-player/playlists/favorites.tsx
+++ b/src/renderer/src/routes/main-player/playlists/favorites.tsx
@@ -13,7 +13,8 @@ import { songSearchSchema } from '@renderer/utils/zod/songSchema';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import { useCallback, useContext } from 'react';
+import storage from '@renderer/utils/localStorage';
+import { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { SpecialPlaylists } from '../../../../../common/playlists.enum';
@@ -43,7 +44,7 @@ function FavoritesPlaylistInfoPage() {
   const queue = useStore(store, (state) => state.localStorage.queue);
   const playlistSortingState = useStore(
     store,
-    (state) => state.localStorage.sortingStates?.songsPage || 'addedOrder'
+    (state) => state.localStorage.sortingStates?.playlistDetailPage || 'addedOrder'
   );
   const preferences = useStore(store, (state) => state.localStorage.preferences);
   const { updateQueueData, addNewNotifications, createQueue, playSong } =
@@ -51,6 +52,10 @@ function FavoritesPlaylistInfoPage() {
   const { t } = useTranslation();
   const { sortingOrder = playlistSortingState } = Route.useSearch();
   const navigate = useNavigate({ from: '/main-player/playlists/favorites' });
+
+  useEffect(() => {
+    storage.sortingStates.setSortingStates('playlistDetailPage', sortingOrder);
+  }, [sortingOrder]);
 
   const { data: favoriteSongs = [] } = useSuspenseQuery({
     ...songQuery.favorites({ sortType: sortingOrder }),

--- a/src/renderer/src/routes/main-player/playlists/history.tsx
+++ b/src/renderer/src/routes/main-player/playlists/history.tsx
@@ -13,7 +13,8 @@ import { songSearchSchema } from '@renderer/utils/zod/songSchema';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import { useCallback, useContext } from 'react';
+import storage from '@renderer/utils/localStorage';
+import { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import historyPlaylistCoverImage from '../../../assets/images/webp/history-playlist-icon.webp';
@@ -41,7 +42,7 @@ function HistoryPlaylistInfoPage() {
   const queue = useStore(store, (state) => state.localStorage.queue);
   const playlistSortingState = useStore(
     store,
-    (state) => state.localStorage.sortingStates?.songsPage || 'addedOrder'
+    (state) => state.localStorage.sortingStates?.playlistDetailPage || 'addedOrder'
   );
   const preferences = useStore(store, (state) => state.localStorage.preferences);
   const { updateQueueData, addNewNotifications, createQueue, playSong } =
@@ -49,6 +50,10 @@ function HistoryPlaylistInfoPage() {
   const { t } = useTranslation();
   const { sortingOrder = playlistSortingState } = Route.useSearch();
   const navigate = useNavigate({ from: '/main-player/playlists/history' });
+
+  useEffect(() => {
+    storage.sortingStates.setSortingStates('playlistDetailPage', sortingOrder);
+  }, [sortingOrder]);
 
   const { data: historySongs = [] } = useSuspenseQuery({
     ...songQuery.history({ sortType: sortingOrder }),

--- a/src/renderer/src/routes/main-player/playlists/history.tsx
+++ b/src/renderer/src/routes/main-player/playlists/history.tsx
@@ -10,10 +10,10 @@ import useSelectAllHandler from '@renderer/hooks/useSelectAllHandler';
 import { songQuery } from '@renderer/queries/songs';
 import { store } from '@renderer/store/store';
 import { songSearchSchema } from '@renderer/utils/zod/songSchema';
+import storage from '@renderer/utils/localStorage';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
-import storage from '@renderer/utils/localStorage';
 import { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -614,6 +614,10 @@ declare global {
     albumsPage?: AlbumSortTypes;
     genresPage?: GenreSortTypes;
     musicFoldersPage?: FolderSortTypes;
+    playlistDetailPage?: SongSortTypes;
+    albumDetailPage?: SongSortTypes;
+    genreDetailPage?: SongSortTypes;
+    artistDetailPage?: SongSortTypes;
   }
 
   interface LyricsEditorSettings {
@@ -1044,7 +1048,11 @@ declare global {
     | 'sortingStates.playlistsPage'
     | 'sortingStates.albumsPage'
     | 'sortingStates.artistsPage'
-    | 'sortingStates.genresPage';
+    | 'sortingStates.genresPage'
+    | 'sortingStates.playlistDetailPage'
+    | 'sortingStates.albumDetailPage'
+    | 'sortingStates.genreDetailPage'
+    | 'sortingStates.artistDetailPage';
 
   type SongFilterTypes =
     | 'notSelected'

--- a/test/src/renderer/src/utils/addMissingPropsToAnObject.test.ts
+++ b/test/src/renderer/src/utils/addMissingPropsToAnObject.test.ts
@@ -1,0 +1,198 @@
+import { describe, test, expect } from 'vitest';
+
+import addMissingPropsToAnObject from '@renderer/utils/addMissingPropsToAnObject';
+
+const TEMPLATE: LocalStorage = {
+  preferences: {
+    seekbarScrollInterval: 5,
+    isSongIndexingEnabled: false,
+    disableBackgroundArtworks: true,
+    doNotShowBlacklistSongConfirm: false,
+    doNotVerifyWhenOpeningLinks: false,
+    isReducedMotion: false,
+    showArtistArtworkNearSongControls: false,
+    showSongRemainingTime: false,
+    noUpdateNotificationForNewUpdate: '',
+    defaultPageOnStartUp: 'Home',
+    enableArtworkFromSongCovers: false,
+    shuffleArtworkFromSongCovers: false,
+    removeAnimationsOnBatteryPower: false,
+    isSimilaritySearchEnabled: true,
+    lyricsAutomaticallySaveState: 'NONE',
+    showTrackNumberAsSongIndex: true,
+    allowToPreventScreenSleeping: true,
+    enableImageBasedDynamicThemes: false,
+    doNotShowHelpPageOnLyricsEditorStartUp: false,
+    autoTranslateLyrics: false,
+    autoConvertLyrics: false
+  },
+  playback: {
+    currentSong: { songId: null, stoppedPosition: 0 },
+    isRepeating: 'false',
+    isShuffling: false,
+    volume: { isMuted: false, value: 50 },
+    playbackRate: 1.0
+  },
+  queue: { position: 0, songIds: [] },
+  sortingStates: {
+    albumsPage: 'aToZ',
+    artistsPage: 'aToZ',
+    genresPage: 'aToZ',
+    playlistsPage: 'aToZ',
+    songsPage: 'aToZ',
+    musicFoldersPage: 'aToZ',
+    playlistDetailPage: 'addedOrder',
+    albumDetailPage: 'trackNoDescending',
+    genreDetailPage: 'aToZ',
+    artistDetailPage: 'aToZ'
+  },
+  equalizerPreset: {
+    thirtyTwoHertzFilter: 0,
+    sixtyFourHertzFilter: 0,
+    hundredTwentyFiveHertzFilter: 0,
+    twoHundredFiftyHertzFilter: 0,
+    fiveHundredHertzFilter: 0,
+    thousandHertzFilter: 0,
+    twoThousandHertzFilter: 0,
+    fourThousandHertzFilter: 0,
+    eightThousandHertzFilter: 0,
+    sixteenThousandHertzFilter: 0
+  },
+  lyricsEditorSettings: {
+    offset: 0,
+    editNextAndCurrentStartAndEndTagsAutomatically: true
+  },
+  keyboardShortcuts: []
+};
+
+describe('addMissingPropsToAnObject with sortingStates', () => {
+  test('should fill in missing detail page sorting keys when loading old localStorage', () => {
+    const oldStorage = {
+      ...TEMPLATE,
+      sortingStates: {
+        albumsPage: 'aToZ' as const,
+        artistsPage: 'aToZ' as const,
+        genresPage: 'aToZ' as const,
+        playlistsPage: 'aToZ' as const,
+        songsPage: 'aToZ' as const,
+        musicFoldersPage: 'aToZ' as const
+      }
+    };
+
+    const onMissing = (key: string) => {
+      expect(['playlistDetailPage', 'albumDetailPage', 'genreDetailPage', 'artistDetailPage']).toContain(key);
+    };
+
+    const result = addMissingPropsToAnObject(TEMPLATE, oldStorage, onMissing);
+    expect(result.sortingStates).toHaveProperty('playlistDetailPage', 'addedOrder');
+    expect(result.sortingStates).toHaveProperty('albumDetailPage', 'trackNoDescending');
+    expect(result.sortingStates).toHaveProperty('genreDetailPage', 'aToZ');
+    expect(result.sortingStates).toHaveProperty('artistDetailPage', 'aToZ');
+    expect(Object.keys(result.sortingStates)).toHaveLength(10);
+  });
+
+  test('should preserve existing detail page sorting keys when present', () => {
+    const currentStorage = {
+      ...TEMPLATE,
+      sortingStates: {
+        songsPage: 'aToZ' as const,
+        artistsPage: 'aToZ' as const,
+        playlistsPage: 'aToZ' as const,
+        albumsPage: 'aToZ' as const,
+        genresPage: 'aToZ' as const,
+        musicFoldersPage: 'aToZ' as const,
+        playlistDetailPage: 'artistNameAscending' as const,
+        albumDetailPage: 'releasedYearDescending' as const,
+        genreDetailPage: 'dateAddedDescending' as const,
+        artistDetailPage: 'trackNoAscending' as const
+      }
+    };
+
+    const onMissing = () => {
+      throw new Error('onMissing should not be called when all keys exist');
+    };
+
+    const result = addMissingPropsToAnObject(TEMPLATE, currentStorage, onMissing);
+    expect(result.sortingStates).toHaveProperty('playlistDetailPage', 'artistNameAscending');
+    expect(result.sortingStates).toHaveProperty('albumDetailPage', 'releasedYearDescending');
+    expect(result.sortingStates).toHaveProperty('genreDetailPage', 'dateAddedDescending');
+    expect(result.sortingStates).toHaveProperty('artistDetailPage', 'trackNoAscending');
+  });
+
+  test('should fill in partial missing keys (only some detail pages present)', () => {
+    const partialStorage = {
+      ...TEMPLATE,
+      sortingStates: {
+        songsPage: 'aToZ' as const,
+        artistsPage: 'aToZ' as const,
+        playlistsPage: 'aToZ' as const,
+        albumsPage: 'aToZ' as const,
+        genresPage: 'aToZ' as const,
+        musicFoldersPage: 'aToZ' as const,
+        playlistDetailPage: 'addedOrder' as const
+      }
+    };
+
+    const missingKeys: string[] = [];
+    const onMissing = (key: string) => { missingKeys.push(key); };
+
+    const result = addMissingPropsToAnObject(TEMPLATE, partialStorage, onMissing);
+    expect(result.sortingStates).toHaveProperty('playlistDetailPage', 'addedOrder');
+    expect(result.sortingStates).toHaveProperty('albumDetailPage', 'trackNoDescending');
+    expect(result.sortingStates).toHaveProperty('genreDetailPage', 'aToZ');
+    expect(result.sortingStates).toHaveProperty('artistDetailPage', 'aToZ');
+    expect(missingKeys).toEqual(['albumDetailPage', 'genreDetailPage', 'artistDetailPage']);
+  });
+
+  test('should not modify the template object', () => {
+    const oldStorage = {
+      ...TEMPLATE,
+      sortingStates: {
+        songsPage: 'aToZ' as const,
+        artistsPage: 'aToZ' as const,
+        playlistsPage: 'aToZ' as const,
+        albumsPage: 'aToZ' as const,
+        genresPage: 'aToZ' as const,
+        musicFoldersPage: 'aToZ' as const
+      }
+    };
+
+    const templateBefore = JSON.stringify(TEMPLATE);
+    addMissingPropsToAnObject(TEMPLATE, oldStorage);
+    expect(JSON.stringify(TEMPLATE)).toBe(templateBefore);
+  });
+
+  test('should handle null/undefined nested values in existing object', () => {
+    const storageWithNullSorting = {
+      ...TEMPLATE,
+      sortingStates: undefined
+    };
+
+    const result = addMissingPropsToAnObject(TEMPLATE, storageWithNullSorting as any);
+    expect(result.sortingStates).toBeDefined();
+    expect(result.sortingStates).toHaveProperty('playlistDetailPage', 'addedOrder');
+    expect(Object.keys(result.sortingStates)).toHaveLength(10);
+  });
+
+  test('should preserve pre-existing top-level keys while filling sortingStates', () => {
+    const oldStorage = {
+      ...TEMPLATE,
+      sortingStates: {
+        songsPage: 'aToZ' as const,
+        artistsPage: 'aToZ' as const,
+        playlistsPage: 'aToZ' as const,
+        albumsPage: 'aToZ' as const,
+        genresPage: 'aToZ' as const,
+        musicFoldersPage: 'aToZ' as const
+      },
+      preferences: {
+        ...TEMPLATE.preferences,
+        showSongRemainingTime: true
+      }
+    };
+
+    const result = addMissingPropsToAnObject(TEMPLATE, oldStorage);
+    expect(result.sortingStates).toHaveProperty('playlistDetailPage', 'addedOrder');
+    expect(result.preferences.showSongRemainingTime).toBe(true);
+  });
+});


### PR DESCRIPTION
### **Summary**

Sort selections on playlist detail, album detail, genre detail, and artist detail pages now persist in localStorage so navigating away and back keeps the users chosen order.

**Root causes**

Detail pages either hardcoded defaults (album, genre, artist) or read from localStorage once on mount but never saved changes back (playlist detail, favorites, history). The list pages (songs, albums, playlists) already had the full save/restore cycle but detail pages were missing it.

**Changes by file**

`src/types/app.d.ts` - add `playlistDetailPage`, `albumDetailPage`, `genreDetailPage`, `artistDetailPage` to `SortingStates` and `PageSortTypes`

`src/renderer/src/other/appReducer.tsx` - add defaults for new keys (`addedOrder`, `trackNoDescending`, `aToZ`, `aToZ`)

`src/renderer/src/routes/main-player/playlists/$playlistId.tsx` - switch from `songsPage` to `playlistDetailPage` key, add useEffect to persist

`src/renderer/src/routes/main-player/playlists/favorites.tsx` - same

`src/renderer/src/routes/main-player/playlists/history.tsx` - same

`src/renderer/src/routes/main-player/albums/$albumId.tsx` - read from `albumDetailPage` localStorage key instead of hardcoded `trackNoDescending`, add `useEffect` to persist

`src/renderer/src/routes/main-player/genres/$genreId.tsx` - read from `genreDetailPage` instead of hardcoded `aToZ`, add `useEffect`

`src/renderer/src/routes/main-player/artists/$artistId.tsx` - read from `artistDetailPage` instead of hardcoded `aToZ`, add `useEffect`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced sorting persistence: Your sorting preferences for albums, artists, genres, and playlists are now automatically saved and restored whenever you navigate between these sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->