### PR TITLE
fix(#419): apply playback rate change instantly from settings

### DIFF
--- a/src/renderer/src/components/SettingsPage/Settings/AudioPlaybackSettings.tsx
+++ b/src/renderer/src/components/SettingsPage/Settings/AudioPlaybackSettings.tsx
@@ -90,6 +90,10 @@ const AudioPlaybackSettings = () => {
                     const val = e.currentTarget.valueAsNumber;
                     setPlaybackRateInterval(val);
                     storage.playback.setPlaybackOptions('playbackRate', val);
+                    store.setState((state) => ({
+                      ...state,
+                      player: { ...state.player, playbackRate: val }
+                    }));
                   }}
                   style={playbackRateSeekBarCssProperties}
                   title={`${playbackRateInterval}x`}
@@ -105,6 +109,10 @@ const AudioPlaybackSettings = () => {
               clickHandler={() => {
                 setPlaybackRateInterval(1);
                 storage.playback.setPlaybackOptions('playbackRate', 1);
+                store.setState((state) => ({
+                  ...state,
+                  player: { ...state.player, playbackRate: 1 }
+                }));
               }}
             />
           </div>

--- a/src/renderer/src/components/SettingsPage/Settings/AudioPlaybackSettings.tsx
+++ b/src/renderer/src/components/SettingsPage/Settings/AudioPlaybackSettings.tsx
@@ -1,4 +1,4 @@
-import { store } from '@renderer/store/store';
+import { dispatch, store } from '@renderer/store/store';
 import { useStore } from '@tanstack/react-store';
 import { useEffect, useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -90,10 +90,7 @@ const AudioPlaybackSettings = () => {
                     const val = e.currentTarget.valueAsNumber;
                     setPlaybackRateInterval(val);
                     storage.playback.setPlaybackOptions('playbackRate', val);
-                    store.setState((state) => ({
-                      ...state,
-                      player: { ...state.player, playbackRate: val }
-                    }));
+                    dispatch({ type: 'UPDATE_PLAYBACK_RATE', data: val });
                   }}
                   style={playbackRateSeekBarCssProperties}
                   title={`${playbackRateInterval}x`}
@@ -109,10 +106,7 @@ const AudioPlaybackSettings = () => {
               clickHandler={() => {
                 setPlaybackRateInterval(1);
                 storage.playback.setPlaybackOptions('playbackRate', 1);
-                store.setState((state) => ({
-                  ...state,
-                  player: { ...state.player, playbackRate: 1 }
-                }));
+                dispatch({ type: 'UPDATE_PLAYBACK_RATE', data: 1 });
               }}
             />
           </div>

--- a/src/renderer/src/other/appReducer.tsx
+++ b/src/renderer/src/other/appReducer.tsx
@@ -66,7 +66,8 @@ export type AppReducerStateActions =
   | {
       type: 'UPDATE_LOCAL_STORAGE_PREFERENCE_ITEM';
       data: { item: string; value: LocalStorage['preferences'] };
-    };
+    }
+  | { type: 'UPDATE_PLAYBACK_RATE'; data: number };
 
 export const reducer = (state: AppReducer, action: AppReducerStateActions): AppReducer => {
   switch (action.type) {
@@ -369,6 +370,14 @@ export const reducer = (state: AppReducer, action: AppReducerStateActions): AppR
       return {
         ...state,
         isOnBatteryPower: action.data ?? state.isOnBatteryPower
+      };
+    case 'UPDATE_PLAYBACK_RATE':
+      return {
+        ...state,
+        player: {
+          ...state.player,
+          playbackRate: action.data ?? state.player.playbackRate
+        }
       };
     default:
       return state;


### PR DESCRIPTION
## Summary

Fixes playback rate not applying immediately when changed in settings.

## Root Cause

The settings slider wrote the new rate to localStorage via storage.playback.setPlaybackOptions but never dispatched the change to the Tanstack store. The player subscribes to store changes and calls updatePlaybackRate() when store.state.player.playbackRate changes, but since settings never updated the store, the player only picked up the rate on app restart when DEFAULT_REDUCER_DATA reads from localStorage.

## Changes

- AudioPlaybackSettings.tsx: Added store.setState dispatch after both the slider onChange and the reset button click, so the player picks up the new rate immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed playback rate synchronization to ensure the app state properly reflects adjustments made through the playback speed slider and reset controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->