### PR TITLE
fix: restore duration-250 Tailwind class and clean up boolean className patterns

### DIFF
--- a/src/renderer/src/components/LyricsPage/LyricLine.tsx
+++ b/src/renderer/src/components/LyricsPage/LyricLine.tsx
@@ -175,10 +175,7 @@ const LyricLine = (props: LyricProp) => {
                 : 'scale-75!'
             }`
           : 'text-font-color-black! dark:text-font-color-white! scale-100! text-4xl! font-medium blur-none! [&>div>span]:mr-3'
-      } ${playerType === 'mini' && 'text-font-color-white/20! mb-2! text-2xl!'} ${
-        playerType === 'full' &&
-        'text-font-color-white/20! mb-6! origin-left items-start! justify-start! text-left! text-7xl!'
-      }`}
+      } ${playerType === 'mini' ? 'text-font-color-white/20! mb-2! text-2xl!' : ''} ${playerType === 'full' ? 'text-font-color-white/20! mb-6! origin-left items-start! justify-start! text-left! text-7xl!' : ''}`}
       ref={lyricsRef}
       onClick={() =>
         syncedLyrics &&
@@ -211,13 +208,13 @@ const LyricLine = (props: LyricProp) => {
     >
       {lyricStringLineSecondaryUpper && (
         <div
-          className={`flex flex-row flex-wrap ${playerType !== 'full' && 'items-center justify-center'} ${syncedLyrics && isInRange ? 'text-font-color-black/50! dark:text-font-color-white/50! text-xl!' : 'text-xl!'}`}
+          className={`flex flex-row flex-wrap ${playerType !== 'full' ? 'items-center justify-center' : ''} ${syncedLyrics && isInRange ? 'text-font-color-black/50! dark:text-font-color-white/50! text-xl!' : 'text-xl!'}`}
         >
           {lyricStringLineSecondaryUpper}
         </div>
       )}
       <div
-        className={`flex flex-row flex-wrap ${playerType !== 'full' && 'items-center justify-center'}`}
+        className={`flex flex-row flex-wrap ${playerType !== 'full' ? 'items-center justify-center' : ''}`}
       >
         {lyricStringLinePrimary}
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -98,6 +98,9 @@ export const theme = {
       'inner-lg': 'inset 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
       'inner-xl': 'inset 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)',
       'inner-2xl': 'inset 0 25px 50px -12px rgb(0 0 0 / 0.25)'
+    },
+    transitionDuration: {
+      '250': '250ms'
     }
   }
 };


### PR DESCRIPTION
Summary

Two pre-existing code quality issues in LyricLine.tsx found during PR #513 review. Neither was introduced by that PR — both trace back to the original ERB-to-Electron-Vite migration.

Root Causes

1.  stopped working after Tailwind v4 migration — v4 removed 250ms from the default transitionDuration scale, so the class generates no CSS. The transition was running at browser default (instant).

2. Boolean  expressions in className template literals inject the string  when the condition fails (e.g.  evaluates to  when playerType is not mini). CSS ignores unknown classes so it's harmless, but produces noisy DOM output.

Changes

- tailwind.config.js: Added  to theme.extend
- LyricLine.tsx: Replaced 4 instances of  with  ternary pattern