### PR TITLE
fix(#520): set AppUserModelId for Windows SMTC integration

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -277,6 +277,10 @@ protocol.registerSchemesAsPrivileged([
   }
 ]);
 
+if (process.platform === 'win32') {
+  app.setAppUserModelId('com.sandakannipunajith.nora');
+}
+
 app
   .whenReady()
   .then(async () => {


### PR DESCRIPTION
Summary

Added app.setAppUserModelId('com.sandakannipunajith.nora') on Windows before app.whenReady() to enable SMTC (System Media Transport Controls) integration.

Root Cause

Nora already implements the Web MediaSession API correctly with play/pause/seek/track handlers, but Windows needs the running process to declare its AppUserModelID for the OS to identify it in the taskbar media flyout and lock screen controls. The electron-builder.yml sets appId at build time, but that does not set the running process's AppUserModelID at runtime.

Changes

- src/main/main.ts: Added app.setAppUserModelId('com.sandakannipunajith.nora') guarded by process.platform === 'win32' check, placed before app.whenReady() so Windows identifies Nora as a media source before the first window loads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows app startup consistency by setting an application identity early in launch, which can help with proper app recognition and behavior on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->