### PR TITLE
fix(#536): heart icon hover square overlay

### DIFF
--- a/src/renderer/src/components/SongsPage/Song.tsx
+++ b/src/renderer/src/components/SongsPage/Song.tsx
@@ -687,7 +687,7 @@ const Song = forwardRef((props: SongProp, ref: ForwardedRef<HTMLDivElement>) => 
         </div>
         <div className="song-duration flex w-full! items-center justify-between pr-4 pl-2 text-center transition-none sm:pr-1">
           <Button
-            className="mt-1 mr-0! rounded-none! border-0! bg-transparent p-0! text-inherit! outline-offset-1 focus-visible:outline! dark:bg-transparent"
+            className="mt-1 mr-0! rounded-none! border-0! bg-transparent p-0! text-inherit! outline-offset-1 focus-visible:outline! hover:bg-transparent dark:bg-transparent dark:hover:bg-transparent"
             iconName="favorite"
             iconClassName={`${
               isAFavorite ? 'material-icons-round' : 'material-icons-round-outlined'


### PR DESCRIPTION
Fixes #536.

The favorite Button in Song.tsx was missing hover background cancellation classes. This caused the default Button hover background to show as a square overlay on hover. Added hover:bg-transparent and dark:hover:bg-transparent to match the pattern used by the sibling play-btn-container Button.

This single change fixes the overlay on all pages that render Song.tsx: Songs, Playlists (including Favorites and History), Albums, Artists, Genres, Folders, Queue, Search results, and Similar Tracks.