### PR TITLE
fix(#537): placeholder images respond to dynamic themes

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path';
 import tailwindcss from '@tailwindcss/vite';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 import react from '@vitejs/plugin-react';
+import svgr from 'vite-plugin-svgr';
 import { defineConfig } from 'electron-vite';
 
 export default defineConfig({
@@ -49,6 +50,15 @@ export default defineConfig({
       }),
       react(),
       // babel({ presets: [reactCompilerPreset()] }),
+      svgr({
+        svgrOptions: {
+          replaceAttrValues: {
+            '#68e1fd': 'currentColor',
+            '#68E1FD': 'currentColor'
+          }
+        },
+        include: '**/*.svg?react'
+      }),
       tailwindcss()
     ]
   }

--- a/src/renderer/src/assets/styles/styles.css
+++ b/src/renderer/src/assets/styles/styles.css
@@ -119,6 +119,7 @@
   --text-color-crimson: 348 83% 47%; /* hsl(348 83% 47%) */
   --text-color-highlight: 203 39% 44%; /* hsl(203 39% 44%) */
   --text-color-highlight-2: 247 74% 63%; /* hsl(247 74% 63%) */
+  --illustration-accent-color: 203 39% 44%; /* hsl(203 39% 44%) */
   --context-menu-background: 0 0% 100%; /* hsl(0 0% 100% / 90%) */
   --context-menu-list-hover: 198 18% 89%; /* hsl(198 18% 89% / 75%) */
   --seekbar-background-color: 0 0% 20%; /* hsl(0 0% 20%) */
@@ -140,6 +141,7 @@
   --dark-text-color-dimmed: 0 0% 50%; /* hsl(0 0% 50%) */
   --dark-text-color-highlight: 213 80% 88%; /* hsl(213 80% 88%) */
   --dark-text-color-highlight-2: 244 98% 80%; /* hsl(244 98% 80%) */
+  --dark-illustration-accent-color: 213 80% 88%; /* hsl(213 80% 88%) */
   --dark-context-menu-background: 228 7% 14%; /* hsla(228 7% 14% / 90%) */
   --dark-context-menu-list-hover: 224 8% 28%; /* hsl(224 8% 28%) */
   --dark-seekbar-background-color: 240 1% 83%; /* hsl(240 1% 83%) */

--- a/src/renderer/src/components/ErrorBoundary.tsx
+++ b/src/renderer/src/components/ErrorBoundary.tsx
@@ -1,7 +1,8 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import BugImg from '../assets/images/svg/Bug Fixed_Monochromatic.svg';
+import BugImg from '../assets/images/svg/Bug Fixed_Monochromatic.svg'?react;
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import log from '../utils/log';
 import Button from './Button';
 
@@ -22,7 +23,7 @@ const ErrorBoundaryFallbackUi = (props: ErrorBoundaryStates) => {
 
   return (
     <div className="text-font-color-black dark:text-font-color-white flex h-full w-full flex-col items-center justify-center overflow-x-hidden">
-      <img src={BugImg} alt="App bug found." className="w-48" />
+      <ThemeableIllustration illustration={BugImg} alt="App bug found." className="w-48" />
       <br />
       <h2>{t('common.somethingWentWrong')}</h2>
       {isInDevelopment && (

--- a/src/renderer/src/components/ErrorBoundary.tsx
+++ b/src/renderer/src/components/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import BugImg from '../assets/images/svg/Bug Fixed_Monochromatic.svg'?react;
+import BugImg from '../assets/images/svg/Bug Fixed_Monochromatic.svg?react';
 import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import log from '../utils/log';
 import Button from './Button';

--- a/src/renderer/src/components/SearchPage/NoSearchResultsContainer.tsx
+++ b/src/renderer/src/components/SearchPage/NoSearchResultsContainer.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import NoResultsImage from '../../assets/images/svg/Sad face_Monochromatic.svg';
+import NoResultsImage from '../../assets/images/svg/Sad face_Monochromatic.svg'?react;
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Img from '../Img';
 import RecentSearchResult from './RecentSearchResult';
 

--- a/src/renderer/src/components/SearchPage/NoSearchResultsContainer.tsx
+++ b/src/renderer/src/components/SearchPage/NoSearchResultsContainer.tsx
@@ -44,8 +44,8 @@ const NoSearchResultsContainer = (props: Props) => {
         genres.length === 0 &&
         searchInput.trim() !== '' && (
           <div className="no-search-results-container active appear-from-bottom relative mt-16 flex w-full flex-col items-center justify-center text-center">
-            <Img
-              src={NoResultsImage}
+            <ThemeableIllustration
+              illustration={NoResultsImage}
               className={
                 songs.length === 0 &&
                 artists.length === 0 &&

--- a/src/renderer/src/components/SearchPage/NoSearchResultsContainer.tsx
+++ b/src/renderer/src/components/SearchPage/NoSearchResultsContainer.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import NoResultsImage from '../../assets/images/svg/Sad face_Monochromatic.svg'?react;
+import NoResultsImage from '../../assets/images/svg/Sad face_Monochromatic.svg?react';
 import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Img from '../Img';
 import RecentSearchResult from './RecentSearchResult';

--- a/src/renderer/src/components/SearchPage/SearchStartPlaceholder.tsx
+++ b/src/renderer/src/components/SearchPage/SearchStartPlaceholder.tsx
@@ -4,7 +4,8 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import SearchSomethingImage from '../../assets/images/svg/Flying kite_Monochromatic.svg';
+import SearchSomethingImage from '../../assets/images/svg/Flying kite_Monochromatic.svg'?react;
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '../Button';
 import Img from '../Img';
 import RecentSearchResult from './RecentSearchResult';

--- a/src/renderer/src/components/SearchPage/SearchStartPlaceholder.tsx
+++ b/src/renderer/src/components/SearchPage/SearchStartPlaceholder.tsx
@@ -59,8 +59,8 @@ const SearchStartPlaceholder = (props: Props) => {
     <>
       {searchInput.trim() === '' && (
         <div className="search-start-placeholder active appear-from-bottom relative flex h-full! w-full flex-col items-center justify-center text-center">
-          <Img
-            src={SearchSomethingImage}
+          <ThemeableIllustration
+            illustration={SearchSomethingImage}
             className={
               searchResults?.songs.length === 0 &&
               searchResults?.artists.length === 0 &&

--- a/src/renderer/src/components/SearchPage/SearchStartPlaceholder.tsx
+++ b/src/renderer/src/components/SearchPage/SearchStartPlaceholder.tsx
@@ -4,7 +4,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import SearchSomethingImage from '../../assets/images/svg/Flying kite_Monochromatic.svg'?react;
+import SearchSomethingImage from '../../assets/images/svg/Flying kite_Monochromatic.svg?react';
 import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '../Button';
 import Img from '../Img';

--- a/src/renderer/src/components/ThemeableIllustration/index.tsx
+++ b/src/renderer/src/components/ThemeableIllustration/index.tsx
@@ -1,0 +1,18 @@
+import type { FC, SVGProps } from 'react';
+
+type Props = SVGProps<SVGSVGElement> & {
+  illustration: FC<SVGProps<SVGSVGElement> & { title?: string }>;
+};
+
+const ThemeableIllustration = ({ illustration: Illustration, className = '', ...props }: Props) => {
+  return (
+    <span
+      className={`text-illustration-accent dark:text-dark-illustration-accent ${className}`}
+      style={{ color: 'hsl(var(--illustration-accent-color))' }}
+    >
+      <Illustration {...props} />
+    </span>
+  );
+};
+
+export default ThemeableIllustration;

--- a/src/renderer/src/hooks/useDynamicTheme.tsx
+++ b/src/renderer/src/hooks/useDynamicTheme.tsx
@@ -50,6 +50,8 @@ const resetStyles = () => {
     root.style.removeProperty('--seekbar-track-background-color');
     root.style.removeProperty('--dark-seekbar-track-background-color');
     root.style.removeProperty('--text-color-highlight-2');
+    root.style.removeProperty('--illustration-accent-color');
+    root.style.removeProperty('--dark-illustration-accent-color');
     root.style.removeProperty('--dark-text-color-highlight-2');
     root.style.removeProperty('--slider-opacity');
     root.style.removeProperty('--dark-slider-opacity');
@@ -165,6 +167,8 @@ export function useDynamicTheme(): UseDynamicThemeReturn {
 
           root.style.setProperty('--text-color-highlight-2', darkVibrant, 'important');
           root.style.setProperty('--dark-text-color-highlight-2', lightVibrant, 'important');
+          root.style.setProperty('--illustration-accent-color', darkVibrant, 'important');
+          root.style.setProperty('--dark-illustration-accent-color', lightVibrant, 'important');
         }
       } else {
         resetStyles();

--- a/src/renderer/src/routes/main-player/albums/index.tsx
+++ b/src/renderer/src/routes/main-player/albums/index.tsx
@@ -1,4 +1,5 @@
-import NoAlbumsImage from '@assets/images/svg/Easter bunny_Monochromatic.svg';
+import NoAlbumsImage from '@assets/images/svg/Easter bunny_Monochromatic.svg'?react;
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import { Album } from '@renderer/components/AlbumsPage/Album';
 import { albumSortOptions } from '@renderer/components/AlbumsPage/AlbumOptions';
 import Button from '@renderer/components/Button';
@@ -180,7 +181,7 @@ function AlbumsPage() {
         )} */}
         {albumsData && albumsData.length === 0 && (
           <div className="no-songs-container text-font-color-black dark:text-font-color-white my-[10%] flex h-full w-full flex-col items-center justify-center text-center text-xl">
-            <Img src={NoAlbumsImage} alt="No songs available." className="mb-8 w-60" />
+            <ThemeableIllustration illustration={NoAlbumsImage} alt="No songs available." className="mb-8 w-60" />
             <div>{t('albumsPage.empty')}</div>
           </div>
         )}

--- a/src/renderer/src/routes/main-player/albums/index.tsx
+++ b/src/renderer/src/routes/main-player/albums/index.tsx
@@ -1,4 +1,4 @@
-import NoAlbumsImage from '@assets/images/svg/Easter bunny_Monochromatic.svg'?react;
+import NoAlbumsImage from '@assets/images/svg/Easter bunny_Monochromatic.svg?react';
 import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import { Album } from '@renderer/components/AlbumsPage/Album';
 import { albumSortOptions } from '@renderer/components/AlbumsPage/AlbumOptions';

--- a/src/renderer/src/routes/main-player/artists/index.tsx
+++ b/src/renderer/src/routes/main-player/artists/index.tsx
@@ -1,4 +1,5 @@
-import NoArtistImage from '@assets/images/svg/Sun_Monochromatic.svg';
+import NoArtistImage from '@assets/images/svg/Sun_Monochromatic.svg'?react;
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import { Artist } from '@renderer/components/ArtistPage/Artist';
 import {
   artistFilterOptions,
@@ -199,7 +200,7 @@ function ArtistPage() {
         )} */}
         {artistsData && artistsData.length === 0 && (
           <div className="no-songs-container text-font-color-black dark:text-font-color-white my-[10%] flex h-full w-full flex-col items-center justify-center text-center text-xl">
-            <Img src={NoArtistImage} alt="Sun in a desert" className="mb-8 w-60" />
+            <ThemeableIllustration illustration={NoArtistImage} alt="Sun in a desert" className="mb-8 w-60" />
             <div>{t('artistsPage.empty')}</div>
           </div>
         )}

--- a/src/renderer/src/routes/main-player/artists/index.tsx
+++ b/src/renderer/src/routes/main-player/artists/index.tsx
@@ -1,4 +1,4 @@
-import NoArtistImage from '@assets/images/svg/Sun_Monochromatic.svg'?react;
+import NoArtistImage from '@assets/images/svg/Sun_Monochromatic.svg?react';
 import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import { Artist } from '@renderer/components/ArtistPage/Artist';
 import {

--- a/src/renderer/src/routes/main-player/folders/index.tsx
+++ b/src/renderer/src/routes/main-player/folders/index.tsx
@@ -1,4 +1,5 @@
-import NoFoldersImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg';
+import NoFoldersImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg'?react;
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '@renderer/components/Button';
 import Dropdown from '@renderer/components/Dropdown';
 import Img from '@renderer/components/Img';
@@ -216,7 +217,7 @@ function MusicFoldersPage() {
 
         {musicFolders.length === 0 && (
           <div className="no-folders-container text-font-color-black dark:text-font-color-white flex h-full flex-col items-center justify-center text-lg">
-            <Img src={NoFoldersImage} className="w-60" />
+            <ThemeableIllustration illustration={NoFoldersImage} className="w-60" />
             <br />
             <p> {t('foldersPage.empty')}</p>
 

--- a/src/renderer/src/routes/main-player/folders/index.tsx
+++ b/src/renderer/src/routes/main-player/folders/index.tsx
@@ -1,4 +1,4 @@
-import NoFoldersImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg'?react;
+import NoFoldersImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg?react';
 import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '@renderer/components/Button';
 import Dropdown from '@renderer/components/Dropdown';

--- a/src/renderer/src/routes/main-player/genres/index.tsx
+++ b/src/renderer/src/routes/main-player/genres/index.tsx
@@ -1,4 +1,4 @@
-import NoSongsImage from '@assets/images/svg/Summer landscape_Monochromatic.svg'?react;
+import NoSongsImage from '@assets/images/svg/Summer landscape_Monochromatic.svg?react';
 import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '@renderer/components/Button';
 import Dropdown from '@renderer/components/Dropdown';

--- a/src/renderer/src/routes/main-player/genres/index.tsx
+++ b/src/renderer/src/routes/main-player/genres/index.tsx
@@ -1,4 +1,5 @@
-import NoSongsImage from '@assets/images/svg/Summer landscape_Monochromatic.svg';
+import NoSongsImage from '@assets/images/svg/Summer landscape_Monochromatic.svg'?react;
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '@renderer/components/Button';
 import Dropdown from '@renderer/components/Dropdown';
 import Genre from '@renderer/components/GenresPage/Genre';
@@ -169,7 +170,7 @@ function GenresPage() {
         </div>
         {genresData === null && (
           <div className="no-songs-container text-font-color-black dark:text-font-color-white my-[10%] flex h-full w-full flex-col items-center justify-center text-center text-xl">
-            <Img src={NoSongsImage} alt="No songs available." className="mb-8 w-60" />
+            <ThemeableIllustration illustration={NoSongsImage} alt="No songs available." className="mb-8 w-60" />
             <span>{t('genresPage.empty')}</span>
           </div>
         )}

--- a/src/renderer/src/routes/main-player/playlists/$playlistId.tsx
+++ b/src/renderer/src/routes/main-player/playlists/$playlistId.tsx
@@ -18,6 +18,8 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useStore } from '@tanstack/react-store';
 import { lazy, useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
+import EmptyStateImage from '../../../assets/images/svg/Empty Inbox _Monochromatic.svg?react';
 
 const SensitiveActionConfirmPrompt = lazy(
   () => import('@renderer/components/SensitiveActionConfirmPrompt')
@@ -273,7 +275,7 @@ function PlaylistInfoPage() {
       />
       {playlistSongs.length === 0 && (
         <div className="no-songs-container appear-from-bottom text-font-color-black dark:text-font-color-white relative flex h-full grow flex-col items-center justify-center text-center text-lg font-light opacity-80!">
-          <span className="material-icons-round-outlined mb-4 text-5xl">brightness_empty</span>
+          <ThemeableIllustration illustration={EmptyStateImage} className="mb-4 w-60" />
           {t('playlist.empty')}
         </div>
       )}

--- a/src/renderer/src/routes/main-player/playlists/favorites.tsx
+++ b/src/renderer/src/routes/main-player/playlists/favorites.tsx
@@ -19,6 +19,8 @@ import { useTranslation } from 'react-i18next';
 
 import { SpecialPlaylists } from '../../../../../common/playlists.enum';
 import favoritesPlaylistCoverImage from '../../../assets/images/webp/favorites-playlist-icon.webp';
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
+import EmptyStateImage from '../../../assets/images/svg/Empty Inbox _Monochromatic.svg?react';
 
 export const Route = createFileRoute('/main-player/playlists/favorites')({
   validateSearch: songSearchSchema,
@@ -275,7 +277,7 @@ function FavoritesPlaylistInfoPage() {
       />
       {favoriteSongs.length === 0 && (
         <div className="no-songs-container appear-from-bottom text-font-color-black dark:text-font-color-white relative flex h-full grow flex-col items-center justify-center text-center text-lg font-light opacity-80!">
-          <span className="material-icons-round-outlined mb-4 text-5xl">brightness_empty</span>
+          <ThemeableIllustration illustration={EmptyStateImage} className="mb-4 w-60" />
           {t('playlist.empty')}
         </div>
       )}

--- a/src/renderer/src/routes/main-player/playlists/history.tsx
+++ b/src/renderer/src/routes/main-player/playlists/history.tsx
@@ -18,6 +18,8 @@ import { useCallback, useContext, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import historyPlaylistCoverImage from '../../../assets/images/webp/history-playlist-icon.webp';
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
+import EmptyStateImage from '../../../assets/images/svg/Empty Inbox _Monochromatic.svg?react';
 export const Route = createFileRoute('/main-player/playlists/history')({
   validateSearch: songSearchSchema,
   component: HistoryPlaylistInfoPage
@@ -253,7 +255,7 @@ function HistoryPlaylistInfoPage() {
       />
       {historySongs.length === 0 && (
         <div className="no-songs-container appear-from-bottom text-font-color-black dark:text-font-color-white relative flex h-full grow flex-col items-center justify-center text-center text-lg font-light opacity-80!">
-          <span className="material-icons-round-outlined mb-4 text-5xl">brightness_empty</span>
+          <ThemeableIllustration illustration={EmptyStateImage} className="mb-4 w-60" />
           {t('playlist.empty')}
         </div>
       )}

--- a/src/renderer/src/routes/main-player/playlists/index.tsx
+++ b/src/renderer/src/routes/main-player/playlists/index.tsx
@@ -1,4 +1,5 @@
-import NoPlaylistsImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg';
+import NoPlaylistsImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg'?react;
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '@renderer/components/Button';
 import Dropdown from '@renderer/components/Dropdown';
 import Img from '@renderer/components/Img';
@@ -256,7 +257,7 @@ function PlaylistsPage() {
         )}
         {playlists.length === 0 && (
           <div className="no-playlists-container text-font-color-black dark:text-font-color-white my-[10%] flex h-full w-full flex-col items-center justify-center text-center text-xl">
-            <Img src={NoPlaylistsImage} alt="" className="mb-8 w-60" />
+            <ThemeableIllustration illustration={NoPlaylistsImage} alt="" className="mb-8 w-60" />
             <span>{t('playlistsPage.empty')}</span>
           </div>
         )}

--- a/src/renderer/src/routes/main-player/playlists/index.tsx
+++ b/src/renderer/src/routes/main-player/playlists/index.tsx
@@ -1,4 +1,4 @@
-import NoPlaylistsImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg'?react;
+import NoPlaylistsImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg?react';
 import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '@renderer/components/Button';
 import Dropdown from '@renderer/components/Dropdown';

--- a/src/renderer/src/routes/main-player/queue/index.tsx
+++ b/src/renderer/src/routes/main-player/queue/index.tsx
@@ -2,7 +2,8 @@ import { Draggable, Droppable, DragDropContext, type DropResult } from '@hello-p
 // import DefaultSongCover from '@renderer/assets/images/webp/song_cover_default.webp';
 // import DefaultPlaylistCover from '@renderer/assets/images/webp/playlist_cover_default.webp';
 // import FolderImg from '@renderer/assets/images/webp/empty-folder.webp';
-import NoSongsImage from '@renderer/assets/images/svg/Sun_Monochromatic.svg';
+import NoSongsImage from '@renderer/assets/images/svg/Sun_Monochromatic.svg'?react;
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '@renderer/components/Button';
 import Img from '@renderer/components/Img';
 import MainContainer from '@renderer/components/MainContainer';
@@ -428,7 +429,7 @@ function RouteComponent() {
           </div>
           {currentQueue.length === 0 && (
             <div className="no-songs-container flex h-full w-full flex-col items-center justify-center text-center text-2xl text-[#ccc]">
-              <Img src={NoSongsImage} className="mb-8 w-60" alt="" /> {t('currentQueuePage.empty')}
+              <ThemeableIllustration illustration={NoSongsImage} className="mb-8 w-60" alt="" /> {t('currentQueuePage.empty')}
             </div>
           )}
         </>

--- a/src/renderer/src/routes/main-player/queue/index.tsx
+++ b/src/renderer/src/routes/main-player/queue/index.tsx
@@ -2,7 +2,7 @@ import { Draggable, Droppable, DragDropContext, type DropResult } from '@hello-p
 // import DefaultSongCover from '@renderer/assets/images/webp/song_cover_default.webp';
 // import DefaultPlaylistCover from '@renderer/assets/images/webp/playlist_cover_default.webp';
 // import FolderImg from '@renderer/assets/images/webp/empty-folder.webp';
-import NoSongsImage from '@renderer/assets/images/svg/Sun_Monochromatic.svg'?react;
+import NoSongsImage from '@renderer/assets/images/svg/Sun_Monochromatic.svg?react';
 import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '@renderer/components/Button';
 import Img from '@renderer/components/Img';

--- a/src/renderer/src/routes/main-player/songs/index.tsx
+++ b/src/renderer/src/routes/main-player/songs/index.tsx
@@ -1,4 +1,5 @@
-import NoSongsImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg';
+import NoSongsImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg'?react;
+import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '@renderer/components/Button';
 import Dropdown from '@renderer/components/Dropdown';
 import Img from '@renderer/components/Img';
@@ -368,7 +369,7 @@ function SongsPage() {
       </div>
       {songData === null && (
         <div className="no-songs-container text-font-color-black dark:text-font-color-white my-[8%] flex h-full w-full flex-col items-center justify-center text-center text-xl">
-          <Img src={NoSongsImage} alt="" className="mb-8 w-60" />
+          <ThemeableIllustration illustration={NoSongsImage} alt="" className="mb-8 w-60" />
           <span>{t('songsPage.empty')}</span>
           <div className="flex items-center justify-between">
             <Button

--- a/src/renderer/src/routes/main-player/songs/index.tsx
+++ b/src/renderer/src/routes/main-player/songs/index.tsx
@@ -1,4 +1,4 @@
-import NoSongsImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg'?react;
+import NoSongsImage from '@assets/images/svg/Empty Inbox _Monochromatic.svg?react';
 import ThemeableIllustration from '@renderer/components/ThemeableIllustration';
 import Button from '@renderer/components/Button';
 import Dropdown from '@renderer/components/Dropdown';

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,1 +1,6 @@
 declare module '*.webp';
+declare module "*.svg?react" {
+  import type { FC, SVGProps } from "react";
+  const ReactComponent: FC<SVGProps<SVGSVGElement> & { title?: string }>;
+  export default ReactComponent;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,7 @@ export const theme = {
       'dark-font-color-highlight': 'hsl(var(--dark-text-color-highlight) / <alpha-value>)',
       'font-color-highlight-2': 'hsl(var(--text-color-highlight-2) / <alpha-value>)',
       'dark-font-color-highlight-2': 'hsl(var(--dark-text-color-highlight-2) / <alpha-value>)',
+      'illustration-accent': 'hsl(var(--illustration-accent-color) / <alpha-value>)',
       'context-menu-background': 'hsl(var(--context-menu-background) / <alpha-value>)',
       'context-menu-list-hover': 'hsl(var(--context-menu-list-hover) / <alpha-value>)',
       'foreground-color-1': 'hsl(var(--foreground-color-1) / <alpha-value>)',


### PR DESCRIPTION
Fixes #537.

The placeholder illustrations in empty states stayed hardcoded blue regardless of the active dynamic theme. This change adds proper theme support through three phases:

Phase 1: SVGR plugin for inline SVG rendering
- Added vite-plugin-svgr to electron.vite.config.ts
- Configured replaceAttrValues to swap #68e1fd to currentColor
- Declared *.svg?react module typing in assets.d.ts

Phase 2: Dynamic accent color
- Added --illustration-accent-color CSS variable with Tailwind token
- Wired into useDynamicTheme.tsx palette derivation and resetStyles

Phase 3: Themeable illustration wrapper
- Created ThemeableIllustration component
- Converted all empty-state placeholders across 13 pages to use inline SVGs with accent color

Affected pages: search, albums, artists, genres, songs, queue, playlists, history, favorites, , folders, ErrorBoundary, and NoSearchResults.